### PR TITLE
Firewall Service - Ability to have iptables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Role Variables
 | `rhel7stig_av_package` | `no` | Anti-virus package(s) to install and service to start and enable. |
 | `rhel7stig_antivirus_required` | `no` | Weather or not an antivirus must be installed |
 | `rhel7stig_time_service` | `chronyd` | Set to `ntpd` or `chronyd`. |
+| `rhel7stig_firewall_service` | `firewalld` | Set to `firewalld` or `iptables`. |
 | `rhel7stig_lftpd_required` | `no` | If set to `no`, remove `lftpd`. |
 | `rhel7stig_tftp_required` | `no` | If set to `no`, remove `tftp` client and server packages. |
 | `rhel7stig_snmp_community` | `Endgam3Ladyb0g` | SNMP community string that will replace `public` and `private` in `snmpd.conf`. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -293,6 +293,8 @@ rhel7stig_time_service_configs:
             - regexp: ^#?maxpoll
               line: maxpoll 10
 
+rhel7stig_firewall_service: firewalld              
+
 # RHEL-07-040490
 # If not required, remove lftpd.
 rhel7stig_lftpd_required: no

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2179,7 +2179,7 @@
       - medium
       - patch
       - RHEL-07-040510
-      - "{{ rhel7stig_firewall_service }}"
+      - firewall
       - notimplemented
 
 - name: "MEDIUM | RHEL-07-040520 | PATCH | The operating system must enable an application firewall, if available."
@@ -2192,7 +2192,7 @@
       - medium
       - patch
       - RHEL-07-040520
-      - "{{ rhel7stig_firewall_service }}"
+      - firewall
 
 - name: "MEDIUM | RHEL-07-040520 | PATCH | The system must use a local firewall."
   service:
@@ -2205,7 +2205,7 @@
       - medium
       - patch
       - RHEL-07-040520
-      - "{{ rhel7stig_firewall_service }}"
+      - firewall
 
 - name: "MEDIUM | RHEL-07-040610 | PATCH | The system must not forward Internet Protocol version 4 (IPv4) source-routed packets."
   sysctl:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2179,12 +2179,12 @@
       - medium
       - patch
       - RHEL-07-040510
-      - firewalld
+      - "{{ rhel7stig_firewall_service }}"
       - notimplemented
 
 - name: "MEDIUM | RHEL-07-040520 | PATCH | The operating system must enable an application firewall, if available."
   yum:
-      name: firewalld
+      name: "{{ rhel7stig_firewall_service }}"
       state: present
   when: rhel_07_040520
   tags:
@@ -2192,11 +2192,11 @@
       - medium
       - patch
       - RHEL-07-040520
-      - firewalld
+      - "{{ rhel7stig_firewall_service }}"
 
 - name: "MEDIUM | RHEL-07-040520 | PATCH | The system must use a local firewall."
   service:
-      name: firewalld
+      name: "{{ rhel7stig_firewall_service }}"
       state: started
       enabled: yes
   when: rhel_07_040520
@@ -2205,7 +2205,7 @@
       - medium
       - patch
       - RHEL-07-040520
-      - firewalld
+      - "{{ rhel7stig_firewall_service }}"
 
 - name: "MEDIUM | RHEL-07-040610 | PATCH | The system must not forward Internet Protocol version 4 (IPv4) source-routed packets."
   sysctl:


### PR DESCRIPTION
With this PR, one will be able to configure whether or not to use `firewalld` or `iptables` (our systems use iptables, so we need this).