### PR TITLE
Adjust ssh tags to match global format

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -69,7 +69,7 @@
       - high
       - patch
       - RHEL-07-010300
-      - sshd
+      - ssh
 
 - name: "HIGH | RHEL-07-010440 | PATCH | The operating system must not allow an unattended or automatic logon to the system."
   lineinfile:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1775,6 +1775,7 @@
       - medium
       - patch
       - RHEL-07-040110
+      - ssh
 
 - name: "MEDIUM | RHEL-07-040160 | PATCH | All network connections associated with a communication session must be terminated at the  the session or after 10 minutes of inactivity from the user at a command prompt, except to fulfill documented and validated mission requirements."
   lineinfile:


### PR DESCRIPTION
Modify RHEL-07-010300 from using tag `sshd` to `ssh`.

Modify RHEL-07-040110 to include `ssh` tag.  