### PR TITLE
correct-sshd-validation (RHEL-07-010470)

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -480,7 +480,7 @@
       dest: /etc/ssh/sshd_config
       regexp: '^#?HostbasedAuthentication'
       line: HostbasedAuthentication no
-      validate: sshd -t -f %s
+      validate: /usr/sbin/sshd -t -f %s
   notify: restart sshd
   tags:
       - cat2


### PR DESCRIPTION
Identified sshd STIG with old `validate` command.  

Correcting `sshd -t -f %s` to `/usr/sbin/sshd -t -f %s`.  

