### PR TITLE
Apply one fix for sshd lastlog

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1926,17 +1926,10 @@
 
 - name: "MEDIUM | RHEL-07-040360 | PATCH | The system must display the date and time of the last successful account logon upon an SSH logon."
   lineinfile:
-      dest: "{{ item.dest }}"
-      regexp: "{{ item.regexp}}"
-      line: "{{ item.line }}"
-      insertbefore: BOF
-  with_items:
-      -   dest: '/etc/ssh/sshd_config'
-          regexp: '^#?PrintLastLog'
-          line: 'PrintLastLog yes'
-      -   dest: '/etc/pam.d/sshd'
-          regexp: '^#?session required pam_lastlog.so'
-          line: 'session required pam_lastlog.so showfailed'
+      dest: /etc/ssh/sshd_config
+      regexp: ^#?PrintLastLog
+      line: PrintLastLog yes
+      validate: /usr/sbin/sshd -t -f %s
   notify: restart sshd
   when: rhel_07_040360
   tags:


### PR DESCRIPTION
The fix for this rule is to modify /etc/pam.d/sshd or /etc/ssh/sshd_config. When both are modified I observed duplicate lastlog lines being printed.