### PR TITLE
Convert rhel7stig_login_defaults.umask to string value.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -426,7 +426,7 @@ rhel7stig_login_defaults:
   pass_min_days: 1
   pass_max_days: 60
   fail_delay_secs: 4
-  umask: 077
+  umask: '077'
   create_home: 'yes'
 
 # RHEL-07-040180


### PR DESCRIPTION
While running some tests I noticed the UMASK setting in /etc/login.defs was being set to the number 63 instead of the expected 077.
Looking into it, python treats all numbers that begin with '0' as octal notation; '077' in octal is 63 in decimal.
Quoting this value (i.e., changing it into a string) resolves this issue.