### PR TITLE
grub2_hash support for older (<1.7) passlib versions

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -2,7 +2,7 @@ try:
     import passlib.hash
     HAS_PASSLIB = True
     PASSLIB_VERSION = float(passlib.__version__[:3])
-except Exception as e:
+except ImportError as e:
     HAS_PASSLIB = False
 
 from ansible import errors

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -1,7 +1,3 @@
-import string
-
-from random import SystemRandom
-
 try:
     import passlib.hash
     HAS_PASSLIB = True
@@ -12,19 +8,31 @@ except Exception as e:
 from ansible import errors
 
 
-def grub2_hash(password, salt=None, iterations=10000):
-    if salt is None:
-        r = SystemRandom()
-        salt = ''.join([r.choice(string.ascii_letters + string.digits) for _ in range(64)])
+def grub2_hash(password, salt=None, iterations=25000):
+    # Build list of keyword arguments to pass into hash/encrypt method
+    kwargs = dict()
+
+    if salt:
+        # passlib generates a random salt of 64 byte length by default (recommended)
+        kwargs['salt'] = salt.encode()
+
+    if iterations:
+        # passlib does 25000 rounds (in version 1.7) by default (recommended or set to a higher value)
+        kwargs['rounds'] = iterations
 
     # Make sure we have passlib and the correct version
     if not HAS_PASSLIB:
         raise errors.AnsibleFilterError('grub2_hash requires the passlib python module to generate password hashes')
 
-    if PASSLIB_VERSION < 1.7:
-        raise errors.AnsibleFilterError('grub2_hash >= 1.7 is required and %s is installed' % passlib.__version__)
+    if PASSLIB_VERSION < 1.5:
+        raise errors.AnsibleFilterError('passlib >= 1.5 is required and %s is installed' % PASSLIB_VERSION)
 
-    encrypted = passlib.hash.grub_pbkdf2_sha512.hash(password, salt=salt.encode(), rounds=iterations)
+    elif PASSLIB_VERSION < 1.7:
+        encrypted = passlib.hash.grub_pbkdf2_sha512.encrypt(password, **kwargs)
+
+    else:
+        encrypted = passlib.hash.grub_pbkdf2_sha512.using(**kwargs).hash(password)
+
     return encrypted
 
 


### PR DESCRIPTION
Per #58 and the comments on #23 some recent systems still have slightly older versions of passlib installed by default. i.e. RHEL7 still uses python-passlib-1.6.5

Updated the filter plugin to support back to 1.5 but it could probably work with as old as 1.4 if necessary. Made some other minor updates as well:

* updated to support older passlib versions back to 1.5
* updated to use the hash() and using() methods on 1.7+ so that the plugin won't die once encrypt() is fully removed
* removed code to generate random salt as passlib does this by default
* removed unneeded python libraries that were used in random salt generation code
* use kwargs to pass user specified values for salt and rounds to the encrypt() or hash() methods
* set default rounds to 25000 to match the default value passlib 1.6+ uses
* catch ImportError instead of generic Exception on the import try/except