### PR TITLE
Adjust ssh key paths to /etc/ssh and valid file patterns

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -147,10 +147,10 @@
 
 - name: "PRELIM | RHEL-07-040410 | The SSH public host key files must have mode 0644 or less permissive."
   find:
-      paths: /
+      paths: /etc/ssh
       recurse: yes
       file_type: file
-      patterns: '*.pub'
+      patterns: 'ssh_host*_key.pub'
       hidden: true
   failed_when: no
   changed_when: no
@@ -166,10 +166,10 @@
 
 - name: "PRELIM | RHEL-07-040420 | The SSH private host key files must have mode 0600 or less permissive."
   find:
-      paths: /
+      paths: /etc/ssh
       recurse: yes
       file_type: file
-      patterns: '*ssh_host*key'
+      patterns: 'ssh_host*_key'
       hidden: true
   failed_when: no
   changed_when: no


### PR DESCRIPTION
As 040410 and 040420 are about ssh host key pairs, it should match the intent and produce fewer side effects if we restrict looking for host keys in /etc/ssh and of the format ssh_host*_key and ssh_host*_key.pub.