### PR TITLE
Audit fixup

### DIFF
--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -3,15 +3,15 @@
 
 - name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.path | basename }} command must be audited."
   lineinfile:
-    path: "/etc/audit/rules.d/rhel7stig_commands.rules"
-    create: yes
-    owner: root
-    group: root
-    mode: 0600
-    line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
-    state: "{{ audit_present | ternary('present', 'absent') }}"
+      path: "/etc/audit/rules.d/rhel7stig_commands.rules"
+      create: yes
+      owner: root
+      group: root
+      mode: 0600
+      line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
+      state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
-    trivial_audit: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
-    normal_audit: "-a always,exit -F path={{ item.path }} -F perm=x -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
-    audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
+      trivial_audit: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
+      normal_audit: "-a always,exit -F path={{ item.path }} -F perm=x -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
+      audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -8,6 +8,9 @@
     owner: root
     group: root
     mode: 0600
-    line: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
+    line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
     state: "{{ item.create | ternary('present', 'absent') }}"
+  vars:
+    trivial_audit: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
+    normal_audit: "-a always,exit -F path={{ item.path }} -F perm=x -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
   notify: restart auditd

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -1,7 +1,7 @@
 ---
 # tasks/audit_command.yml
 
-- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ item.create | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.path | basename }} command must be audited."
+- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.path | basename }} command must be audited."
   lineinfile:
     path: "/etc/audit/rules.d/rhel7stig_commands.rules"
     create: yes
@@ -9,8 +9,9 @@
     group: root
     mode: 0600
     line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
-    state: "{{ item.create | ternary('present', 'absent') }}"
+    state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
     trivial_audit: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
     normal_audit: "-a always,exit -F path={{ item.path }} -F perm=x -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
+    audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_file.yml
+++ b/tasks/audit_file.yml
@@ -1,7 +1,7 @@
 ---
 # tasks/audit_file.yml
 
-- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ item.create | ternary('PATCH', 'REVERT') }} | The operating system must generate audit records for all {{ item.description }}."
+- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | The operating system must generate audit records for all {{ item.description }}."
   lineinfile:
     path: "/etc/audit/rules.d/rhel7stig_files.rules"
     create: yes
@@ -9,5 +9,7 @@
     group: root
     mode: 0600
     line: "-w {{ item.path }} -p wa -k {{ item.key }}"
-    state: "{{ item.create | ternary('present', 'absent') }}"
+    state: "{{ audit_present | ternary('present', 'absent') }}"
+  vars:
+    audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_file.yml
+++ b/tasks/audit_file.yml
@@ -3,13 +3,13 @@
 
 - name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | The operating system must generate audit records for all {{ item.description }}."
   lineinfile:
-    path: "/etc/audit/rules.d/rhel7stig_files.rules"
-    create: yes
-    owner: root
-    group: root
-    mode: 0600
-    line: "-w {{ item.path }} -p wa -k {{ item.key }}"
-    state: "{{ audit_present | ternary('present', 'absent') }}"
+      path: "/etc/audit/rules.d/rhel7stig_files.rules"
+      create: yes
+      owner: root
+      group: root
+      mode: 0600
+      line: "-w {{ item.path }} -p wa -k {{ item.key }}"
+      state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
-    audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
+      audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_system_call.yml
+++ b/tasks/audit_system_call.yml
@@ -3,18 +3,18 @@
 
 - name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.call }} command must be audited."
   lineinfile:
-    path: "/etc/audit/rules.d/rhel7stig_system_calls.rules"
-    create: yes
-    owner: root
-    group: root
-    mode: 0600
-    line: "-a always,exit -F arch={{ arch }} -S {{ item.call }} {% if item.extra_fields is defined %}{{ item.extra_fields }} {% endif %}{{ item.include_all_auids | default(false) | ternary('', '-F auid>=1000 -F auid!=4294967295 ') }}-k {{ item.key }}"
-    state: "{{ audit_present | ternary('present', 'absent') }}"
+      path: "/etc/audit/rules.d/rhel7stig_system_calls.rules"
+      create: yes
+      owner: root
+      group: root
+      mode: 0600
+      line: "-a always,exit -F arch={{ arch }} -S {{ item.call }} {% if item.extra_fields is defined %}{{ item.extra_fields }} {% endif %}{{ item.include_all_auids | default(false) | ternary('', '-F auid>=1000 -F auid!=4294967295 ') }}-k {{ item.key }}"
+      state: "{{ audit_present | ternary('present', 'absent') }}"
   with_items:
-    - b64
-    - b32
+      - b64
+      - b32
   loop_control:
-    loop_var: arch
+      loop_var: arch
   vars:
-    audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
+      audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_system_call.yml
+++ b/tasks/audit_system_call.yml
@@ -8,6 +8,11 @@
     owner: root
     group: root
     mode: 0600
-    line: "-a always,exit -F arch=b64 {% if item.call is defined %}-S {{ item.call }}{% elif item.path is defined %}-F path={{item.path}}{% endif %} {{ item.extra_fields | default('') }} {%if item.include_all_auids is defined %}{% else %}-F auid>=1000 -F auid!=4294967295{% endif %} -k {{ item.key }}"
+    line: "-a always,exit -F arch={{ arch }} {% if item.call is defined %}-S {{ item.call }}{% elif item.path is defined %}-F path={{item.path}}{% endif %} {{ item.extra_fields | default('') }} {%if item.include_all_auids is defined %}{% else %}-F auid>=1000 -F auid!=4294967295{% endif %} -k {{ item.key }}"
     state: "{{ item.create | ternary('present', 'absent') }}"
+  with_items:
+    - b64
+    - b32
+  loop_control:
+    loop_var: arch
   notify: restart auditd

--- a/tasks/audit_system_call.yml
+++ b/tasks/audit_system_call.yml
@@ -1,7 +1,7 @@
 ---
 # tasks/audit_system_call.yml
 
-- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ item.create | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.call }} command must be audited."
+- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.call }} command must be audited."
   lineinfile:
     path: "/etc/audit/rules.d/rhel7stig_system_calls.rules"
     create: yes
@@ -9,10 +9,12 @@
     group: root
     mode: 0600
     line: "-a always,exit -F arch={{ arch }} -S {{ item.call }} {% if item.extra_fields is defined %}{{ item.extra_fields }} {% endif %}{{ item.include_all_auids | default(false) | ternary('', '-F auid>=1000 -F auid!=4294967295 ') }}-k {{ item.key }}"
-    state: "{{ item.create | ternary('present', 'absent') }}"
+    state: "{{ audit_present | ternary('present', 'absent') }}"
   with_items:
     - b64
     - b32
   loop_control:
     loop_var: arch
+  vars:
+    audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_system_call.yml
+++ b/tasks/audit_system_call.yml
@@ -1,14 +1,14 @@
 ---
 # tasks/audit_system_call.yml
 
-- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ item.create | ternary('PATCH', 'REVERT') }} | All uses of the {% if item.call is defined %}{{ item.call }}{% elif item.path is defined %}{{item.path | basename}}{% endif %} command must be audited."
+- name: "MEDIUM | RHEL-07-{{ item.id }} | {{ item.create | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.call }} command must be audited."
   lineinfile:
     path: "/etc/audit/rules.d/rhel7stig_system_calls.rules"
     create: yes
     owner: root
     group: root
     mode: 0600
-    line: "-a always,exit {% if item.call is defined %}-F arch={{ arch }} -S {{ item.call }}{% elif item.path is defined %}-F path={{item.path}}{% endif %} {{ item.extra_fields | default('') }} {%if item.include_all_auids is defined %}{% else %}-F auid>=1000 -F auid!=4294967295{% endif %} -k {{ item.key }}"
+    line: "-a always,exit -F arch={{ arch }} -S {{ item.call }} {% if item.extra_fields is defined %}{{ item.extra_fields }} {% endif %}{{ item.include_all_auids | default(false) | ternary('', '-F auid>=1000 -F auid!=4294967295 ') }}-k {{ item.key }}"
     state: "{{ item.create | ternary('present', 'absent') }}"
   with_items:
     - b64

--- a/tasks/audit_system_call.yml
+++ b/tasks/audit_system_call.yml
@@ -8,7 +8,7 @@
     owner: root
     group: root
     mode: 0600
-    line: "-a always,exit -F arch={{ arch }} {% if item.call is defined %}-S {{ item.call }}{% elif item.path is defined %}-F path={{item.path}}{% endif %} {{ item.extra_fields | default('') }} {%if item.include_all_auids is defined %}{% else %}-F auid>=1000 -F auid!=4294967295{% endif %} -k {{ item.key }}"
+    line: "-a always,exit {% if item.call is defined %}-F arch={{ arch }} -S {{ item.call }}{% elif item.path is defined %}-F path={{item.path}}{% endif %} {{ item.extra_fields | default('') }} {%if item.include_all_auids is defined %}{% else %}-F auid>=1000 -F auid!=4294967295{% endif %} -k {{ item.key }}"
     state: "{{ item.create | ternary('present', 'absent') }}"
   with_items:
     - b64

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1212,84 +1212,84 @@
 - name: "MEDIUM | Auditing system calls"
   include_tasks: audit_system_call.yml
   with_items:
-    - {id: "030370", call: "chown", key: "perm_mod", create: "{{ rhel_07_030370 }}"}
-    - {id: "030380", call: "fchown", key: "perm_mod", create: "{{ rhel_07_030380 }}"}
-    - {id: "030390", call: "lchown", key: "perm_mod", create: "{{ rhel_07_030390 }}"}
-    - {id: "030400", call: "fchownat", key: "perm_mod", create: "{{ rhel_07_030400 }}"}
-    - {id: "030410", call: "chmod", key: "perm_mod", create: "{{ rhel_07_030410 }}"}
-    - {id: "030420", call: "fchmod", key: "perm_mod", create: "{{ rhel_07_030420 }}"}
-    - {id: "030430", call: "fchmodat", key: "perm_mod", create: "{{ rhel_07_030430 }}"}
-    - {id: "030440", call: "setxattr", key: "perm_mod", create: "{{ rhel_07_030440 }}"}
-    - {id: "030450", call: "fsetxattr", key: "perm_mod", create: "{{ rhel_07_030450 }}"}
-    - {id: "030460", call: "lsetxattr", key: "perm_mod", create: "{{ rhel_07_030460 }}"}
-    - {id: "030470", call: "removexattr", key: "perm_mod", create: "{{ rhel_07_030470 }}"}
-    - {id: "030480", call: "fremovexattr", key: "perm_mod", create: "{{ rhel_07_030480 }}"}
-    - {id: "030490", call: "lremovexattr", key: "perm_mod", create: "{{ rhel_07_030490 }}"}
-    - {id: "030500", call: "creat", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030500 }}"}
-    - {id: "030500", call: "creat", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030500 }}"}
-    - {id: "030510", call: "open", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030510 }}"}
-    - {id: "030510", call: "open", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030510 }}"}
-    - {id: "030520", call: "openat", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030520 }}"}
-    - {id: "030520", call: "openat", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030520 }}"}
-    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030530 }}"}
-    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030530 }}"}
-    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030540 }}"}
-    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030540 }}"}
-    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030550 }}"}
-    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030550 }}"}
-    - {id: "030740", call: "mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
-    - {id: "030819", call: "create_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030819 }}"}
-    - {id: "030820", call: "init_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030820 }}"}
-    - {id: "030821", call: "finit_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030821 }}"}
-    - {id: "030830", call: "delete_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030830 }}"}
-    - {id: "030880", call: "rename", key: "delete", create: "{{ rhel_07_030880 }}"}
-    - {id: "030890", call: "renameat", key: "delete", create: "{{ rhel_07_030890 }}"}
-    - {id: "030900", call: "rmdir", key: "delete", create: "{{ rhel_07_030900 }}"}
-    - {id: "030910", call: "unlink", key: "delete", create: "{{ rhel_07_030910 }}"}
-    - {id: "030920", call: "unlinkat", key: "delete", create: "{{ rhel_07_030920 }}"}
+    - {id: "030370", call: "chown", key: "perm_mod"}
+    - {id: "030380", call: "fchown", key: "perm_mod"}
+    - {id: "030390", call: "lchown", key: "perm_mod"}
+    - {id: "030400", call: "fchownat", key: "perm_mod"}
+    - {id: "030410", call: "chmod", key: "perm_mod"}
+    - {id: "030420", call: "fchmod", key: "perm_mod"}
+    - {id: "030430", call: "fchmodat", key: "perm_mod"}
+    - {id: "030440", call: "setxattr", key: "perm_mod"}
+    - {id: "030450", call: "fsetxattr", key: "perm_mod"}
+    - {id: "030460", call: "lsetxattr", key: "perm_mod"}
+    - {id: "030470", call: "removexattr", key: "perm_mod"}
+    - {id: "030480", call: "fremovexattr", key: "perm_mod"}
+    - {id: "030490", call: "lremovexattr", key: "perm_mod"}
+    - {id: "030500", call: "creat", extra_fields: "-F exit=-EPERM", key: "access"}
+    - {id: "030500", call: "creat", extra_fields: "-F exit=-EACCES", key: "access"}
+    - {id: "030510", call: "open", extra_fields: "-F exit=-EPERM", key: "access"}
+    - {id: "030510", call: "open", extra_fields: "-F exit=-EACCES", key: "access"}
+    - {id: "030520", call: "openat", extra_fields: "-F exit=-EPERM", key: "access"}
+    - {id: "030520", call: "openat", extra_fields: "-F exit=-EACCES", key: "access"}
+    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EPERM", key: "access"}
+    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EACCES", key: "access"}
+    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EACCES", key: "access"}
+    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EPERM", key: "access"}
+    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EACCES", key: "access"}
+    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EPERM", key: "access"}
+    - {id: "030740", call: "mount", key: "privileged-mount"}
+    - {id: "030819", call: "create_module", include_all_auids: yes, key: "module-change"}
+    - {id: "030820", call: "init_module", include_all_auids: yes, key: "module-change"}
+    - {id: "030821", call: "finit_module", include_all_auids: yes, key: "module-change"}
+    - {id: "030830", call: "delete_module", include_all_auids: yes, key: "module-change"}
+    - {id: "030880", call: "rename", key: "delete"}
+    - {id: "030890", call: "renameat", key: "delete"}
+    - {id: "030900", call: "rmdir", key: "delete"}
+    - {id: "030910", call: "unlink", key: "delete"}
+    - {id: "030920", call: "unlinkat", key: "delete"}
 
 - name: "MEDIUM | Auditing commands"
   include_tasks: audit_command.yml
   with_items:
-    - {id: "030560", path: "/usr/sbin/semanage", key: "privileged-priv_change", create: "{{ rhel_07_030560 }}"}
-    - {id: "030570", path: "/usr/sbin/setsebool", key: "privileged-priv_change", create: "{{ rhel_07_030570 }}"}
-    - {id: "030580", path: "/usr/bin/chcon", key: "privileged-priv_change", create: "{{ rhel_07_030580 }}"}
-    - {id: "030590", path: "/usr/sbin/setfiles", key: "privileged-priv_change", create: "{{ rhel_07_030590 }}"}
-    - {id: "030630", path: "/usr/bin/passwd", key: "privileged-passwd", create: "{{ rhel_07_030630 }}"}
-    - {id: "030640", path: "/usr/sbin/unix_chkpwd", key: "privileged-passwd", create: "{{ rhel_07_030640 }}"}
-    - {id: "030650", path: "/usr/bin/gpasswd", key: "privileged-passwd", create: "{{ rhel_07_030650 }}"}
-    - {id: "030660", path: "/usr/bin/chage", key: "privileged-passwd", create: "{{ rhel_07_030660 }}"}
-    - {id: "030670", path: "/usr/sbin/userhelper", key: "privileged-passwd", create: "{{ rhel_07_030670 }}"}
-    - {id: "030680", path: "/usr/bin/su", key: "privileged-priv_change", create: "{{ rhel_07_030680 }}"}
-    - {id: "030690", path: "/usr/bin/sudo", key: "privileged-priv_change", create: "{{ rhel_07_030690 }}"}
-    - {id: "030710", path: "/usr/bin/newgrp", key: "privileged-priv_change", create: "{{ rhel_07_030710 }}"}
-    - {id: "030720", path: "/usr/bin/chsh", key: "privileged-priv_change", create: "{{ rhel_07_030720 }}"}
-    - {id: "030730", path: "/bin/sudoedit", key: "privileged-priv_change", create: "{{ rhel_07_030730 }}"}
-    - {id: "030740", path: "/bin/mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
-    - {id: "030740", path: "/usr/bin/mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
-    - {id: "030750", path: "/bin/umount", key: "privileged-mount", create: "{{ rhel_07_030750 }}"}
-    - {id: "030760", path: "/usr/sbin/postdrop", key: "privileged-postfix", create: "{{ rhel_07_030760 }}"}
-    - {id: "030770", path: "/usr/sbin/postqueue", key: "privileged-postfix", create: "{{ rhel_07_030770 }}"}
-    - {id: "030780", path: "/usr/libexec/openssh/ssh-keysign", key: "privileged-ssh", create: "{{ rhel_07_030780 }}"}
-    - {id: "030800", path: "/usr/bin/crontab", key: "privileged-cron", create: "{{ rhel_07_030800 }}"}
-    - {id: "030810", path: "/sbin/pam_timestamp_check", key: "privileged-pam", create: "{{ rhel_07_030810 }}"}
-    - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module-change", create: "{{ rhel_07_030840 }}"}
-    - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module-change", create: "{{ rhel_07_030850 }}"}
-    - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module-change", create: "{{ rhel_07_030860 }}"}
+    - {id: "030560", path: "/usr/sbin/semanage", key: "privileged-priv_change"}
+    - {id: "030570", path: "/usr/sbin/setsebool", key: "privileged-priv_change"}
+    - {id: "030580", path: "/usr/bin/chcon", key: "privileged-priv_change"}
+    - {id: "030590", path: "/usr/sbin/setfiles", key: "privileged-priv_change"}
+    - {id: "030630", path: "/usr/bin/passwd", key: "privileged-passwd"}
+    - {id: "030640", path: "/usr/sbin/unix_chkpwd", key: "privileged-passwd"}
+    - {id: "030650", path: "/usr/bin/gpasswd", key: "privileged-passwd"}
+    - {id: "030660", path: "/usr/bin/chage", key: "privileged-passwd"}
+    - {id: "030670", path: "/usr/sbin/userhelper", key: "privileged-passwd"}
+    - {id: "030680", path: "/usr/bin/su", key: "privileged-priv_change"}
+    - {id: "030690", path: "/usr/bin/sudo", key: "privileged-priv_change"}
+    - {id: "030710", path: "/usr/bin/newgrp", key: "privileged-priv_change"}
+    - {id: "030720", path: "/usr/bin/chsh", key: "privileged-priv_change"}
+    - {id: "030730", path: "/bin/sudoedit", key: "privileged-priv_change"}
+    - {id: "030740", path: "/bin/mount", key: "privileged-mount"}
+    - {id: "030740", path: "/usr/bin/mount", key: "privileged-mount"}
+    - {id: "030750", path: "/bin/umount", key: "privileged-mount"}
+    - {id: "030760", path: "/usr/sbin/postdrop", key: "privileged-postfix"}
+    - {id: "030770", path: "/usr/sbin/postqueue", key: "privileged-postfix"}
+    - {id: "030780", path: "/usr/libexec/openssh/ssh-keysign", key: "privileged-ssh"}
+    - {id: "030800", path: "/usr/bin/crontab", key: "privileged-cron"}
+    - {id: "030810", path: "/sbin/pam_timestamp_check", key: "privileged-pam"}
+    - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module-change"}
+    - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module-change"}
+    - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module-change"}
 
 - name: "MEDIUM | Auditing files"
   include_tasks: audit_file.yml
   with_items:
-    - {id: "030600", path: "/var/log/tallylog", description: "successful/unsuccessful account access count events", key: "logins", create: "{{ rhel_07_030600 }}"}
-    - {id: "030610", path: "/var/run/faillock", description: "unsuccessful account access events", key: "logins", create: "{{ rhel_07_030610 }}"}
-    - {id: "030620", path: "/var/log/lastlog", description: "successful account access events", key: "logins", create: "{{ rhel_07_030620 }}"}
-    - {id: "030700", path: "/etc/sudoers", description: "modifications to sudoers", key: "privileged-actions", create: "{{ rhel_07_030700 }}"}
-    - {id: "030700", path: "/etc/sudoers.d/", description: "modifications to sudoers", key: "privileged-actions", create: "{{ rhel_07_030700 }}"}
-    - {id: "030870", path: "/etc/passwd", description: "account creations, modifications, disabling, and termination events that affect /etc/passwd", key: "identity", create: "{{ rhel_07_030870 }}"}
-    - {id: "030871", path: "/etc/group", description: "account creations, modifications, disabling, and termination events that affect /etc/group", key: "identity", create: "{{ rhel_07_030871 }}"}
-    - {id: "030872", path: "/etc/gshadow", description: "account creations, modifications, disabling, and termination events that affect /etc/gshadow", key: "identity", create: "{{ rhel_07_030872 }}"}
-    - {id: "030873", path: "/etc/shadow", description: "account creations, modifications, disabling, and termination events that affect /etc/shadow", key: "identity", create: "{{ rhel_07_030873 }}"}
-    - {id: "030874", path: "/etc/security/opasswd", description: "account creations, modifications, disabling, and termination events that affect /etc/security/opasswd", key: "identity", create: "{{ rhel_07_030874 }}"}
+    - {id: "030600", path: "/var/log/tallylog", description: "successful/unsuccessful account access count events", key: "logins"}
+    - {id: "030610", path: "/var/run/faillock", description: "unsuccessful account access events", key: "logins"}
+    - {id: "030620", path: "/var/log/lastlog", description: "successful account access events", key: "logins"}
+    - {id: "030700", path: "/etc/sudoers", description: "modifications to sudoers", key: "privileged-actions"}
+    - {id: "030700", path: "/etc/sudoers.d/", description: "modifications to sudoers", key: "privileged-actions"}
+    - {id: "030870", path: "/etc/passwd", description: "account creations, modifications, disabling, and termination events that affect /etc/passwd", key: "identity"}
+    - {id: "030871", path: "/etc/group", description: "account creations, modifications, disabling, and termination events that affect /etc/group", key: "identity"}
+    - {id: "030872", path: "/etc/gshadow", description: "account creations, modifications, disabling, and termination events that affect /etc/gshadow", key: "identity"}
+    - {id: "030873", path: "/etc/shadow", description: "account creations, modifications, disabling, and termination events that affect /etc/shadow", key: "identity"}
+    - {id: "030874", path: "/etc/security/opasswd", description: "account creations, modifications, disabling, and termination events that affect /etc/security/opasswd", key: "identity"}
 
 - name: "MEDIUM | RHEL-07-031000 | PATCH | The system must send rsyslog output to a log aggregation server."
   command: "true"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1334,6 +1334,9 @@
         call: "unlinkat"
         key: "delete"
   tags:
+      - cat2
+      - medium
+      - patch
       - audit-rules
 
 - name: "MEDIUM | Auditing commands"
@@ -1418,6 +1421,9 @@
         trivial: yes
         key: "module-change"
   tags:
+      - cat2
+      - medium
+      - patch
       - audit-rules
 
 - name: "MEDIUM | Auditing files"
@@ -1464,6 +1470,9 @@
         description: "account creations, modifications, disabling, and termination events that affect /etc/security/opasswd"
         key: "identity"
   tags:
+      - cat2
+      - medium
+      - patch
       - audit-rules
 
 - name: "MEDIUM | RHEL-07-031000 | PATCH | The system must send rsyslog output to a log aggregation server."

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1273,9 +1273,9 @@
     - {id: "030780", path: "/usr/libexec/openssh/ssh-keysign", key: "privileged-ssh", create: "{{ rhel_07_030780 }}"}
     - {id: "030800", path: "/usr/bin/crontab", key: "privileged-cron", create: "{{ rhel_07_030800 }}"}
     - {id: "030810", path: "/sbin/pam_timestamp_check", key: "privileged-pam", create: "{{ rhel_07_030810 }}"}
-    - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module_change", create: "{{ rhel_07_030840 }}"}
-    - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module_change", create: "{{ rhel_07_030850 }}"}
-    - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module_change", create: "{{ rhel_07_030860 }}"}
+    - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module-change", create: "{{ rhel_07_030840 }}"}
+    - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module-change", create: "{{ rhel_07_030850 }}"}
+    - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module-change", create: "{{ rhel_07_030860 }}"}
 
 - name: "MEDIUM | Auditing files"
   include_tasks: audit_file.yml

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1242,7 +1242,7 @@
     - {id: "030580", path: "/usr/bin/chcon", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030580 }}"}
     - {id: "030590", path: "/usr/sbin/setfiles", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030590 }}"}
     - {id: "030630", path: "/usr/bin/passwd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030630 }}"}
-    - {id: "030640", path: "/usr/bin/unix_chkpwd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030640 }}"}
+    - {id: "030640", path: "/usr/sbin/unix_chkpwd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030640 }}"}
     - {id: "030650", path: "/usr/bin/gpasswd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030650 }}"}
     - {id: "030660", path: "/usr/bin/chage", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030660 }}"}
     - {id: "030670", path: "/usr/sbin/userhelper", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030670 }}"}

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1226,16 +1226,16 @@
     - {id: "030480", call: "fremovexattr", key: "perm_mod", create: "{{ rhel_07_030480 }}"}
     - {id: "030490", call: "lremovexattr", key: "perm_mod", create: "{{ rhel_07_030490 }}"}
     - {id: "030500", call: "creat", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030500 }}"}
-    - {id: "030500", call: "creat", extra_fields: "-F exit=-EACCESS", key: "access", create: "{{ rhel_07_030500 }}"}
+    - {id: "030500", call: "creat", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030500 }}"}
     - {id: "030510", call: "open", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030510 }}"}
-    - {id: "030510", call: "open", extra_fields: "-F exit=-EACCESS", key: "access", create: "{{ rhel_07_030510 }}"}
+    - {id: "030510", call: "open", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030510 }}"}
     - {id: "030520", call: "openat", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030520 }}"}
-    - {id: "030520", call: "openat", extra_fields: "-F exit=-EACCESS", key: "access", create: "{{ rhel_07_030520 }}"}
+    - {id: "030520", call: "openat", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030520 }}"}
     - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030530 }}"}
-    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EACCESS", key: "access", create: "{{ rhel_07_030530 }}"}
-    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EACCESS", key: "access", create: "{{ rhel_07_030540 }}"}
+    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030530 }}"}
+    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030540 }}"}
     - {id: "030540", call: "truncate", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030540 }}"}
-    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EACCESS", key: "access", create: "{{ rhel_07_030550 }}"}
+    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030550 }}"}
     - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030550 }}"}
     - {id: "030560", path: "/usr/sbin/semanage", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030560 }}"}
     - {id: "030570", path: "/usr/sbin/setsebool", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030570 }}"}

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1237,29 +1237,7 @@
     - {id: "030540", call: "truncate", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030540 }}"}
     - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EACCES", key: "access", create: "{{ rhel_07_030550 }}"}
     - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EPERM", key: "access", create: "{{ rhel_07_030550 }}"}
-    - {id: "030560", path: "/usr/sbin/semanage", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030560 }}"}
-    - {id: "030570", path: "/usr/sbin/setsebool", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030570 }}"}
-    - {id: "030580", path: "/usr/bin/chcon", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030580 }}"}
-    - {id: "030590", path: "/usr/sbin/setfiles", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030590 }}"}
-    - {id: "030630", path: "/usr/bin/passwd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030630 }}"}
-    - {id: "030640", path: "/usr/sbin/unix_chkpwd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030640 }}"}
-    - {id: "030650", path: "/usr/bin/gpasswd", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030650 }}"}
-    - {id: "030660", path: "/usr/bin/chage", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030660 }}"}
-    - {id: "030670", path: "/usr/sbin/userhelper", extra_fields: "-F perm=x", key: "privileged-passwd", create: "{{ rhel_07_030670 }}"}
-    - {id: "030680", path: "/usr/bin/su", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030680 }}"}
-    - {id: "030690", path: "/usr/bin/sudo", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030690 }}"}
-    - {id: "030710", path: "/usr/bin/newgrp", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030710 }}"}
-    - {id: "030720", path: "/usr/bin/chsh", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030720 }}"}
-    - {id: "030730", path: "/bin/sudoedit", extra_fields: "-F perm=x", key: "privileged-priv_change", create: "{{ rhel_07_030730 }}"}
     - {id: "030740", call: "mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
-    - {id: "030740", path: "/bin/mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
-    - {id: "030740", path: "/usr/bin/mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
-    - {id: "030750", path: "/bin/umount", extra_fields: "-F perm=x", key: "privileged-mount", create: "{{ rhel_07_030750 }}"}
-    - {id: "030760", path: "/usr/sbin/postdrop", extra_fields: "-F perm=x", key: "privileged-postfix", create: "{{ rhel_07_030760 }}"}
-    - {id: "030770", path: "/usr/sbin/postqueue", extra_fields: "-F perm=x", key: "privileged-postfix", create: "{{ rhel_07_030770 }}"}
-    - {id: "030780", path: "/usr/libexec/openssh/ssh-keysign", extra_fields: "-F perm=x", key: "privileged-ssh", create: "{{ rhel_07_030780 }}"}
-    - {id: "030800", path: "/usr/bin/crontab", extra_fields: "-F perm=x", key: "privileged-cron", create: "{{ rhel_07_030800 }}"}
-    - {id: "030810", path: "/sbin/pam_timestamp_check", extra_fields: "-F perm=x", key: "privileged-pam", create: "{{ rhel_07_030810 }}"}
     - {id: "030819", call: "create_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030819 }}"}
     - {id: "030820", call: "init_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030820 }}"}
     - {id: "030821", call: "finit_module", include_all_auids: yes, key: "module-change", create: "{{ rhel_07_030821 }}"}
@@ -1273,9 +1251,31 @@
 - name: "MEDIUM | Auditing commands"
   include_tasks: audit_command.yml
   with_items:
-    - {id: "030840", path: "/sbin/insmod", key: "module_change", create: "{{ rhel_07_030840 }}"}
-    - {id: "030850", path: "/sbin/rmmod", key: "module_change", create: "{{ rhel_07_030850 }}"}
-    - {id: "030860", path: "/sbin/modprobe", key: "module_change", create: "{{ rhel_07_030860 }}"}
+    - {id: "030560", path: "/usr/sbin/semanage", key: "privileged-priv_change", create: "{{ rhel_07_030560 }}"}
+    - {id: "030570", path: "/usr/sbin/setsebool", key: "privileged-priv_change", create: "{{ rhel_07_030570 }}"}
+    - {id: "030580", path: "/usr/bin/chcon", key: "privileged-priv_change", create: "{{ rhel_07_030580 }}"}
+    - {id: "030590", path: "/usr/sbin/setfiles", key: "privileged-priv_change", create: "{{ rhel_07_030590 }}"}
+    - {id: "030630", path: "/usr/bin/passwd", key: "privileged-passwd", create: "{{ rhel_07_030630 }}"}
+    - {id: "030640", path: "/usr/sbin/unix_chkpwd", key: "privileged-passwd", create: "{{ rhel_07_030640 }}"}
+    - {id: "030650", path: "/usr/bin/gpasswd", key: "privileged-passwd", create: "{{ rhel_07_030650 }}"}
+    - {id: "030660", path: "/usr/bin/chage", key: "privileged-passwd", create: "{{ rhel_07_030660 }}"}
+    - {id: "030670", path: "/usr/sbin/userhelper", key: "privileged-passwd", create: "{{ rhel_07_030670 }}"}
+    - {id: "030680", path: "/usr/bin/su", key: "privileged-priv_change", create: "{{ rhel_07_030680 }}"}
+    - {id: "030690", path: "/usr/bin/sudo", key: "privileged-priv_change", create: "{{ rhel_07_030690 }}"}
+    - {id: "030710", path: "/usr/bin/newgrp", key: "privileged-priv_change", create: "{{ rhel_07_030710 }}"}
+    - {id: "030720", path: "/usr/bin/chsh", key: "privileged-priv_change", create: "{{ rhel_07_030720 }}"}
+    - {id: "030730", path: "/bin/sudoedit", key: "privileged-priv_change", create: "{{ rhel_07_030730 }}"}
+    - {id: "030740", path: "/bin/mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
+    - {id: "030740", path: "/usr/bin/mount", key: "privileged-mount", create: "{{ rhel_07_030740 }}"}
+    - {id: "030750", path: "/bin/umount", key: "privileged-mount", create: "{{ rhel_07_030750 }}"}
+    - {id: "030760", path: "/usr/sbin/postdrop", key: "privileged-postfix", create: "{{ rhel_07_030760 }}"}
+    - {id: "030770", path: "/usr/sbin/postqueue", key: "privileged-postfix", create: "{{ rhel_07_030770 }}"}
+    - {id: "030780", path: "/usr/libexec/openssh/ssh-keysign", key: "privileged-ssh", create: "{{ rhel_07_030780 }}"}
+    - {id: "030800", path: "/usr/bin/crontab", key: "privileged-cron", create: "{{ rhel_07_030800 }}"}
+    - {id: "030810", path: "/sbin/pam_timestamp_check", key: "privileged-pam", create: "{{ rhel_07_030810 }}"}
+    - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module_change", create: "{{ rhel_07_030840 }}"}
+    - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module_change", create: "{{ rhel_07_030850 }}"}
+    - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module_change", create: "{{ rhel_07_030860 }}"}
 
 - name: "MEDIUM | Auditing files"
   include_tasks: audit_file.yml

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1212,90 +1212,259 @@
 - name: "MEDIUM | Auditing system calls"
   include_tasks: audit_system_call.yml
   with_items:
-    - {id: "030370", call: "chown", key: "perm_mod"}
-    - {id: "030380", call: "fchown", key: "perm_mod"}
-    - {id: "030390", call: "lchown", key: "perm_mod"}
-    - {id: "030400", call: "fchownat", key: "perm_mod"}
-    - {id: "030410", call: "chmod", key: "perm_mod"}
-    - {id: "030420", call: "fchmod", key: "perm_mod"}
-    - {id: "030430", call: "fchmodat", key: "perm_mod"}
-    - {id: "030440", call: "setxattr", key: "perm_mod"}
-    - {id: "030450", call: "fsetxattr", key: "perm_mod"}
-    - {id: "030460", call: "lsetxattr", key: "perm_mod"}
-    - {id: "030470", call: "removexattr", key: "perm_mod"}
-    - {id: "030480", call: "fremovexattr", key: "perm_mod"}
-    - {id: "030490", call: "lremovexattr", key: "perm_mod"}
-    - {id: "030500", call: "creat", extra_fields: "-F exit=-EPERM", key: "access"}
-    - {id: "030500", call: "creat", extra_fields: "-F exit=-EACCES", key: "access"}
-    - {id: "030510", call: "open", extra_fields: "-F exit=-EPERM", key: "access"}
-    - {id: "030510", call: "open", extra_fields: "-F exit=-EACCES", key: "access"}
-    - {id: "030520", call: "openat", extra_fields: "-F exit=-EPERM", key: "access"}
-    - {id: "030520", call: "openat", extra_fields: "-F exit=-EACCES", key: "access"}
-    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EPERM", key: "access"}
-    - {id: "030530", call: "open_by_handle_at", extra_fields: "-F exit=-EACCES", key: "access"}
-    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EACCES", key: "access"}
-    - {id: "030540", call: "truncate", extra_fields: "-F exit=-EPERM", key: "access"}
-    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EACCES", key: "access"}
-    - {id: "030550", call: "ftruncate", extra_fields: "-F exit=-EPERM", key: "access"}
-    - {id: "030740", call: "mount", key: "privileged-mount"}
-    - {id: "030819", call: "create_module", include_all_auids: yes, key: "module-change"}
-    - {id: "030820", call: "init_module", include_all_auids: yes, key: "module-change"}
-    - {id: "030821", call: "finit_module", include_all_auids: yes, key: "module-change"}
-    - {id: "030830", call: "delete_module", include_all_auids: yes, key: "module-change"}
-    - {id: "030880", call: "rename", key: "delete"}
-    - {id: "030890", call: "renameat", key: "delete"}
-    - {id: "030900", call: "rmdir", key: "delete"}
-    - {id: "030910", call: "unlink", key: "delete"}
-    - {id: "030920", call: "unlinkat", key: "delete"}
+      - id: "030370"
+        call: "chown"
+        key: "perm_mod"
+      - id: "030380"
+        call: "fchown"
+        key: "perm_mod"
+      - id: "030390"
+        call: "lchown"
+        key: "perm_mod"
+      - id: "030400"
+        call: "fchownat"
+        key: "perm_mod"
+      - id: "030410"
+        call: "chmod"
+        key: "perm_mod"
+      - id: "030420"
+        call: "fchmod"
+        key: "perm_mod"
+      - id: "030430"
+        call: "fchmodat"
+        key: "perm_mod"
+      - id: "030440"
+        call: "setxattr"
+        key: "perm_mod"
+      - id: "030450"
+        call: "fsetxattr"
+        key: "perm_mod"
+      - id: "030460"
+        call: "lsetxattr"
+        key: "perm_mod"
+      - id: "030470"
+        call: "removexattr"
+        key: "perm_mod"
+      - id: "030480"
+        call: "fremovexattr"
+        key: "perm_mod"
+      - id: "030490"
+        call: "lremovexattr"
+        key: "perm_mod"
+      - id: "030500"
+        call: "creat"
+        extra_fields: "-F exit=-EPERM"
+        key: "access"
+      - id: "030500"
+        call: "creat"
+        extra_fields: "-F exit=-EACCES"
+        key: "access"
+      - id: "030510"
+        call: "open"
+        extra_fields: "-F exit=-EPERM"
+        key: "access"
+      - id: "030510"
+        call: "open"
+        extra_fields: "-F exit=-EACCES"
+        key: "access"
+      - id: "030520"
+        call: "openat"
+        extra_fields: "-F exit=-EPERM"
+        key: "access"
+      - id: "030520"
+        call: "openat"
+        extra_fields: "-F exit=-EACCES"
+        key: "access"
+      - id: "030530"
+        call: "open_by_handle_at"
+        extra_fields: "-F exit=-EPERM"
+        key: "access"
+      - id: "030530"
+        call: "open_by_handle_at"
+        extra_fields: "-F exit=-EACCES"
+        key: "access"
+      - id: "030540"
+        call: "truncate"
+        extra_fields: "-F exit=-EACCES"
+        key: "access"
+      - id: "030540"
+        call: "truncate"
+        extra_fields: "-F exit=-EPERM"
+        key: "access"
+      - id: "030550"
+        call: "ftruncate"
+        extra_fields: "-F exit=-EACCES"
+        key: "access"
+      - id: "030550"
+        call: "ftruncate"
+        extra_fields: "-F exit=-EPERM"
+        key: "access"
+      - id: "030740"
+        call: "mount"
+        key: "privileged-mount"
+      - id: "030819"
+        call: "create_module"
+        include_all_auids: yes
+        key: "module-change"
+      - id: "030820"
+        call: "init_module"
+        include_all_auids: yes
+        key: "module-change"
+      - id: "030821"
+        call: "finit_module"
+        include_all_auids: yes
+        key: "module-change"
+      - id: "030830"
+        call: "delete_module"
+        include_all_auids: yes
+        key: "module-change"
+      - id: "030880"
+        call: "rename"
+        key: "delete"
+      - id: "030890"
+        call: "renameat"
+        key: "delete"
+      - id: "030900"
+        call: "rmdir"
+        key: "delete"
+      - id: "030910"
+        call: "unlink"
+        key: "delete"
+      - id: "030920"
+        call: "unlinkat"
+        key: "delete"
   tags:
-    - audit-rules
+      - audit-rules
 
 - name: "MEDIUM | Auditing commands"
   include_tasks: audit_command.yml
   with_items:
-    - {id: "030560", path: "/usr/sbin/semanage", key: "privileged-priv_change"}
-    - {id: "030570", path: "/usr/sbin/setsebool", key: "privileged-priv_change"}
-    - {id: "030580", path: "/usr/bin/chcon", key: "privileged-priv_change"}
-    - {id: "030590", path: "/usr/sbin/setfiles", key: "privileged-priv_change"}
-    - {id: "030630", path: "/usr/bin/passwd", key: "privileged-passwd"}
-    - {id: "030640", path: "/usr/sbin/unix_chkpwd", key: "privileged-passwd"}
-    - {id: "030650", path: "/usr/bin/gpasswd", key: "privileged-passwd"}
-    - {id: "030660", path: "/usr/bin/chage", key: "privileged-passwd"}
-    - {id: "030670", path: "/usr/sbin/userhelper", key: "privileged-passwd"}
-    - {id: "030680", path: "/usr/bin/su", key: "privileged-priv_change"}
-    - {id: "030690", path: "/usr/bin/sudo", key: "privileged-priv_change"}
-    - {id: "030710", path: "/usr/bin/newgrp", key: "privileged-priv_change"}
-    - {id: "030720", path: "/usr/bin/chsh", key: "privileged-priv_change"}
-    - {id: "030730", path: "/bin/sudoedit", key: "privileged-priv_change"}
-    - {id: "030740", path: "/bin/mount", key: "privileged-mount"}
-    - {id: "030740", path: "/usr/bin/mount", key: "privileged-mount"}
-    - {id: "030750", path: "/bin/umount", key: "privileged-mount"}
-    - {id: "030760", path: "/usr/sbin/postdrop", key: "privileged-postfix"}
-    - {id: "030770", path: "/usr/sbin/postqueue", key: "privileged-postfix"}
-    - {id: "030780", path: "/usr/libexec/openssh/ssh-keysign", key: "privileged-ssh"}
-    - {id: "030800", path: "/usr/bin/crontab", key: "privileged-cron"}
-    - {id: "030810", path: "/sbin/pam_timestamp_check", key: "privileged-pam"}
-    - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module-change"}
-    - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module-change"}
-    - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module-change"}
+      - id: "030560"
+        path: "/usr/sbin/semanage"
+        key: "privileged-priv_change"
+      - id: "030570"
+        path: "/usr/sbin/setsebool"
+        key: "privileged-priv_change"
+      - id: "030580"
+        path: "/usr/bin/chcon"
+        key: "privileged-priv_change"
+      - id: "030590"
+        path: "/usr/sbin/setfiles"
+        key: "privileged-priv_change"
+      - id: "030630"
+        path: "/usr/bin/passwd"
+        key: "privileged-passwd"
+      - id: "030640"
+        path: "/usr/sbin/unix_chkpwd"
+        key: "privileged-passwd"
+      - id: "030650"
+        path: "/usr/bin/gpasswd"
+        key: "privileged-passwd"
+      - id: "030660"
+        path: "/usr/bin/chage"
+        key: "privileged-passwd"
+      - id: "030670"
+        path: "/usr/sbin/userhelper"
+        key: "privileged-passwd"
+      - id: "030680"
+        path: "/usr/bin/su"
+        key: "privileged-priv_change"
+      - id: "030690"
+        path: "/usr/bin/sudo"
+        key: "privileged-priv_change"
+      - id: "030710"
+        path: "/usr/bin/newgrp"
+        key: "privileged-priv_change"
+      - id: "030720"
+        path: "/usr/bin/chsh"
+        key: "privileged-priv_change"
+      - id: "030730"
+        path: "/bin/sudoedit"
+        key: "privileged-priv_change"
+      - id: "030740"
+        path: "/bin/mount"
+        key: "privileged-mount"
+      - id: "030740"
+        path: "/usr/bin/mount"
+        key: "privileged-mount"
+      - id: "030750"
+        path: "/bin/umount"
+        key: "privileged-mount"
+      - id: "030760"
+        path: "/usr/sbin/postdrop"
+        key: "privileged-postfix"
+      - id: "030770"
+        path: "/usr/sbin/postqueue"
+        key: "privileged-postfix"
+      - id: "030780"
+        path: "/usr/libexec/openssh/ssh-keysign"
+        key: "privileged-ssh"
+      - id: "030800"
+        path: "/usr/bin/crontab"
+        key: "privileged-cron"
+      - id: "030810"
+        path: "/sbin/pam_timestamp_check"
+        key: "privileged-pam"
+      - id: "030840"
+        path: "/sbin/insmod"
+        trivial: yes
+        key: "module-change"
+      - id: "030850"
+        path: "/sbin/rmmod"
+        trivial: yes
+        key: "module-change"
+      - id: "030860"
+        path: "/sbin/modprobe"
+        trivial: yes
+        key: "module-change"
   tags:
-    - audit-rules
+      - audit-rules
 
 - name: "MEDIUM | Auditing files"
   include_tasks: audit_file.yml
   with_items:
-    - {id: "030600", path: "/var/log/tallylog", description: "successful/unsuccessful account access count events", key: "logins"}
-    - {id: "030610", path: "/var/run/faillock", description: "unsuccessful account access events", key: "logins"}
-    - {id: "030620", path: "/var/log/lastlog", description: "successful account access events", key: "logins"}
-    - {id: "030700", path: "/etc/sudoers", description: "modifications to sudoers", key: "privileged-actions"}
-    - {id: "030700", path: "/etc/sudoers.d/", description: "modifications to sudoers", key: "privileged-actions"}
-    - {id: "030870", path: "/etc/passwd", description: "account creations, modifications, disabling, and termination events that affect /etc/passwd", key: "identity"}
-    - {id: "030871", path: "/etc/group", description: "account creations, modifications, disabling, and termination events that affect /etc/group", key: "identity"}
-    - {id: "030872", path: "/etc/gshadow", description: "account creations, modifications, disabling, and termination events that affect /etc/gshadow", key: "identity"}
-    - {id: "030873", path: "/etc/shadow", description: "account creations, modifications, disabling, and termination events that affect /etc/shadow", key: "identity"}
-    - {id: "030874", path: "/etc/security/opasswd", description: "account creations, modifications, disabling, and termination events that affect /etc/security/opasswd", key: "identity"}
+      - id: "030600"
+        path: "/var/log/tallylog"
+        description: "successful/unsuccessful account access count events"
+        key: "logins"
+      - id: "030610"
+        path: "/var/run/faillock"
+        description: "unsuccessful account access events"
+        key: "logins"
+      - id: "030620"
+        path: "/var/log/lastlog"
+        description: "successful account access events"
+        key: "logins"
+      - id: "030700"
+        path: "/etc/sudoers"
+        description: "modifications to sudoers"
+        key: "privileged-actions"
+      - id: "030700"
+        path: "/etc/sudoers.d/"
+        description: "modifications to sudoers"
+        key: "privileged-actions"
+      - id: "030870"
+        path: "/etc/passwd"
+        description: "account creations, modifications, disabling, and termination events that affect /etc/passwd"
+        key: "identity"
+      - id: "030871"
+        path: "/etc/group"
+        description: "account creations, modifications, disabling, and termination events that affect /etc/group"
+        key: "identity"
+      - id: "030872"
+        path: "/etc/gshadow"
+        description: "account creations, modifications, disabling, and termination events that affect /etc/gshadow"
+        key: "identity"
+      - id: "030873"
+        path: "/etc/shadow"
+        description: "account creations, modifications, disabling, and termination events that affect /etc/shadow"
+        key: "identity"
+      - id: "030874"
+        path: "/etc/security/opasswd"
+        description: "account creations, modifications, disabling, and termination events that affect /etc/security/opasswd"
+        key: "identity"
   tags:
-    - audit-rules
+      - audit-rules
 
 - name: "MEDIUM | RHEL-07-031000 | PATCH | The system must send rsyslog output to a log aggregation server."
   command: "true"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1247,6 +1247,8 @@
     - {id: "030900", call: "rmdir", key: "delete"}
     - {id: "030910", call: "unlink", key: "delete"}
     - {id: "030920", call: "unlinkat", key: "delete"}
+  tags:
+    - audit-rules
 
 - name: "MEDIUM | Auditing commands"
   include_tasks: audit_command.yml
@@ -1276,6 +1278,8 @@
     - {id: "030840", path: "/sbin/insmod", trivial: yes, key: "module-change"}
     - {id: "030850", path: "/sbin/rmmod", trivial: yes, key: "module-change"}
     - {id: "030860", path: "/sbin/modprobe", trivial: yes, key: "module-change"}
+  tags:
+    - audit-rules
 
 - name: "MEDIUM | Auditing files"
   include_tasks: audit_file.yml
@@ -1290,6 +1294,8 @@
     - {id: "030872", path: "/etc/gshadow", description: "account creations, modifications, disabling, and termination events that affect /etc/gshadow", key: "identity"}
     - {id: "030873", path: "/etc/shadow", description: "account creations, modifications, disabling, and termination events that affect /etc/shadow", key: "identity"}
     - {id: "030874", path: "/etc/security/opasswd", description: "account creations, modifications, disabling, and termination events that affect /etc/security/opasswd", key: "identity"}
+  tags:
+    - audit-rules
 
 - name: "MEDIUM | RHEL-07-031000 | PATCH | The system must send rsyslog output to a log aggregation server."
   command: "true"


### PR DESCRIPTION
audit loop fixes:
- audit both 32 and 64-bit system calls
- fix -EACCES error-causing typo
- commands audited migrated to audit_commands.yml
- eliminated need for separate "create" parameter
- reformatted code to match guidelines

Please merge rather than squash.