### PR TITLE
Working on RHEL-07-040820.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -439,6 +439,9 @@ rhel7stig_auth_settings:
     use_ldap: no
     use_sssd: no
 
+# RHEL-07-040820
+rhel7stig_ipsec_required: no
+
 # RHEL-07-010340
 # Setting to enable or disable fixes that depend on password-based authentication
 # i.e. if users authenticate with a means other than passwords (pubkey)

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2017,16 +2017,17 @@
       - RHEL-07-040810
       - notimplemented
 
-- name: "MEDIUM | RHEL-07-040820 | PATCH | The system must not have unauthorized IP tunnels configured."
-  command: "true"
-  changed_when: no
+- name: "MEDIUM | RHEL-07-040820 | PATCH | The system must not have unauthorized IP tunnels configured{{ rhel7stig_ipsec_required | ternary(' (exception should have been documented with ISSO)','') }}."
+  yum:
+    name:
+      - libreswan
+    state: "{{rhel7stig_ipsec_required | ternary('present', 'absent') }}"
   when: rhel_07_040820
   tags:
       - cat2
       - medium
       - patch
       - RHEL-07-040820
-      - notimplemented
 
 - name: "MEDIUM | RHEL-07-040830 | PATCH | The system must not forward IPv6 source-routed packets."
   sysctl:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2017,11 +2017,11 @@
       - RHEL-07-040810
       - notimplemented
 
-- name: "MEDIUM | RHEL-07-040820 | PATCH | The system must not have unauthorized IP tunnels configured{{ rhel7stig_ipsec_required | ternary(' (exception should have been documented with ISSO)','') }}."
+- name: "MEDIUM | RHEL-07-040820 | PATCH | The system must not have unauthorized IP tunnels configured."
   yum:
     name:
       - libreswan
-    state: "{{rhel7stig_ipsec_required | ternary('present', 'absent') }}"
+    state: absent
   when: rhel_07_040820
   tags:
       - cat2


### PR DESCRIPTION
Shouldn't cause any harm, as it appears the IPSec service won't be enabled automatically. By default, libreswan would be removed. If the site decides they need IPsec and enable that variable, libreswan will be installed, but won't run by default.

The only way a site gets a finding is if they:

- set `rhel7stig_ipsec_needed` to true and apply the role
- manually enable the service (not a part of this role)
- fail to notify their ISSO of any exceptions