### PR TITLE
Add/Remove STIG IDs based on STIG release 4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,6 @@ rhel_07_010050: true
 rhel_07_010060: true
 rhel_07_010061: true
 rhel_07_010070: true
-rhel_07_010080: true
 rhel_07_010081: true
 rhel_07_010082: true
 rhel_07_010090: true
@@ -243,7 +242,6 @@ rhel_07_040830: true
 rhel_07_041001: true
 rhel_07_041002: true
 rhel_07_041003: true
-rhel_07_041004: true
 rhel_07_041010: true
 # CAT 3 rules
 rhel_07_020200: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ rhel_07_010081: true
 rhel_07_010082: true
 rhel_07_010090: true
 rhel_07_010100: true
+rhel_07_010101: true
 rhel_07_010110: true
 rhel_07_010119: true
 rhel_07_010120: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ rhel_07_010040: true
 rhel_07_010050: true
 rhel_07_010060: true
 rhel_07_010061: true
+rhel_07_010062: true
 rhel_07_010070: true
 rhel_07_010081: true
 rhel_07_010082: true

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -84,19 +84,6 @@
       - RHEL-07-010070
       - notimplemented
 
-- name: "MEDIUM | RHEL-07-010080 | PATCH | The operating system must set the idle delay setting for all connection types."
-  command: "true"
-  changed_when: no
-  when:
-      - rhel7stig_gui
-      - rhel_07_010080
-  tags:
-      - cat2
-      - medium
-      - patch
-      - RHEL-07-010080
-      - notimplemented
-
 - name: "MEDIUM | RHEL-07-010081 | PATCH | The operating system must set the lock delay setting for all connection types."
   command: "true"
   changed_when: no

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2382,20 +2382,6 @@
       - RHEL-07-041003
       - notimplemented
 
-- name: "MEDIUM | RHEL-07-041004 | PATCH | The operating system must implement smart card logons for multifactor authentication for access to privileged accounts."
-  command: "true"
-  changed_when: no
-  when:
-      - rhel7stig_gui
-      - rhel_07_041004
-  tags:
-      - cat2
-      - medium
-      - patch
-      - RHEL-07-041004
-      - multifactor
-      - notimplemented
-
 - name: "MEDIUM | RHEL-07-041010 | PATCH | Wireless network adapters must be disabled."
   command: nmcli radio wifi off
   changed_when: no

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -71,6 +71,16 @@
       - RHEL-07-010061
       - notimplemented
 
+- name: "MEDIUM | RHEL-07-010062 | PATCH | The operating system must prevent a user from overriding the screensaver lock-enabled setting for the graphical user interface."
+  command: "true"
+  changed_when: no
+  when:
+      - rhel7stig_gui
+      - rhel_07_010062
+  tags:
+      - RHEL-07-010062
+      - notimplemented
+
 - name: "MEDIUM | RHEL-07-010070 | PATCH | The operating system must initiate a screensaver after a 15-minute period of inactivity for graphical user interfaces."
   command: "true"
   changed_when: no

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -144,6 +144,16 @@
       - RHEL-07-010100
       - notimplemented
 
+- name: "MEDIUM | RHEL-07-010101 | PATCH | The operating system must prevent a user from overriding the screensaver idle-activation-enabled setting for the graphical user interface."
+  command: "true"
+  changed_when: no
+  when:
+      - rhel7stig_gui
+      - rhel_07_010101
+  tags:
+      - RHEL-07-010101
+      - notimplemented
+
 - name: "MEDIUM | RHEL-07-010110 | PATCH | The operating system must initiate a session lock for graphical user interfaces when the screensaver is activated."
   command: "true"
   changed_when: no


### PR DESCRIPTION
- This removes STIG ID **RHEL-07-041004** and **RHEL-07-010080** per Version 1 Release 4.
- This adds placeholder tasks and vars for STIG ID **RHEL-07-010062** and **RHEL-07-010101** per Version 1 Release 4.