### PR TITLE
Updating RHEL-07-040690 to V1R4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Role Variables
 | `rhel7stig_time_service` | `chronyd` | Set to `ntpd` or `chronyd`. |
 | `rhel7stig_time_service_configs` | [see defaults/main.yml](./defaults/main.yml) | Time service packages and service configs. |
 | `rhel7stig_firewall_service` | `firewalld` | Set to `firewalld` or `iptables`. |
-| `rhel7stig_lftpd_required` | `no` | If set to `no`, remove `lftpd`. |
+| `rhel7stig_vsftpd_required` | `no` | If set to `no`, remove `vsftpd`. |
 | `rhel7stig_tftp_required` | `no` | If set to `no`, remove `tftp` client and server packages. |
 | `rhel7stig_autofs_required` | `no` | If set to `no`, disable `autofs` service. |
 | `rhel7stig_kdump_required` | `no` | If set to `no`, disable `kdump` service. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -302,8 +302,8 @@ rhel7stig_firewall_service: firewalld
 rhel7stig_system_is_log_aggregator: false
 
 # RHEL-07-040490
-# If not required, remove lftpd.
-rhel7stig_lftpd_required: no
+# If not required, remove vsftpd.
+rhel7stig_vsftpd_required: no
 
 # RHEL-07-040500
 # If not required, remove tftp

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -473,10 +473,10 @@
 
 - name: "HIGH | RHEL-07-040690 | PATCH | A File Transfer Protocol (FTP) server package must not be installed unless needed."
   yum:
-      name: lftpd
+      name: vsftpd
       state: absent
   when:
-      - not rhel7stig_lftpd_required
+      - not rhel7stig_vsftpd_required
       - rhel_07_040690
   tags:
       - cat1


### PR DESCRIPTION
`lftpd` was replaced with `vsftpd`.