### PR TITLE
Updating RHEL-07-010480 and RHEL-07-010490 to V1R4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Role Variables
 | `rhel7stig_kdump_required` | `no` | If set to `no`, disable `kdump` service. |
 | `rhel7stig_snmp_community` | `Endgam3Ladyb0g` | SNMP community string that will replace `public` and `private` in `snmpd.conf`. |
 | `rhel7stig_bootloader_password` | `Boot1tUp!` | GRUB2 bootloader password. This should be stored in an Ansible Vault. |
-| `rhel7stig_boot_superuser` | `root` | Used to set the boot superuser in the GRUB2 config. |
 | `rhel7stig_boot_password_config` | [see defaults/main.yml](./defaults/main.yml) | GRUB2 bootloader password configuration. |
 | `rhel7stig_aide_cron` | [see defaults/main.yml](./defaults/main.yml) | AIDE Cron settings |
 | `rhel7stig_maxlogins` | `10` | Set maximum number of simultaneous system logins (RHEL-07-040000) |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -320,10 +320,9 @@ rhel7stig_snmp_community: Endgam3Ladyb0g
 # RHEL-07-010460 and RHEL-07-010470
 # Password protect the boot loader
 rhel7stig_bootloader_password: 'Boot1tUp!'
-rhel7stig_boot_superuser: root
 rhel7stig_boot_password_config:
     - regexp: ^set superusers
-      line: 'set superusers="{{rhel7stig_boot_superuser}}"'
+      line: 'set superusers="root"'
 
     - regexp: ^password_pbkdf2 {{rhel7stig_boot_superuser}}
       line: password_pbkdf2 {{rhel7stig_boot_superuser}} {{ rhel7stig_bootloader_password | grub2_hash(salt='KeokpkECTJeoDhEA5XtiLQ') }}


### PR DESCRIPTION
V1R4 of RHEL-07-010480 and RHEL-07-010490 require the grub superuser to be root.