### PR TITLE
remove time limit from aide init

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -24,11 +24,7 @@
       state: restarted
 
 - name: init aide
-  command: /usr/sbin/aide --init -B 'database_out=file:/var/lib/aide/aide.db.gz'
-  async: 45
-  poll: 0
-  tags:
-    - aide
+  shell: nohup /usr/sbin/aide --init -B 'database_out=file:/var/lib/aide/aide.db.gz' > /dev/null &
 
 - name: restart auditd
   command: service auditd restart


### PR DESCRIPTION
as written, aide init was killed after 45 seconds, which is
not enough time for it to run in our environments

turn it into a true fire-and-forget task