### PR TITLE
Implementing 032010

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -282,7 +282,10 @@ rhel7stig_av_package:
 # RHEL-07-032010
 # How to check if your definitions are up to date. Passed to an Ansible
 # shell task, and that task's stdout_lines will be printed in a debug task.
-rhel7stig_av_status_command: "savlog | grep 'Successfully updated' | tail -2"
+rhel7stig_av_status_command: "ls -l $(grep -i '^DatabaseDirectory' /etc/clamav.conf | awk '{print $NF}')/*.cvd"
+# For ClamAV: "ls -l $(grep -i '^DatabaseDirectory' /etc/clamav.conf | awk '{print $NF}')/*.cvd"
+# For McAfee: "ls -l /opt/NAI/LinuxShield/engine/dat/*.dat"
+# For Sophos: "/opt/sophos-av/bin/savlog | grep 'Successfully updated' | tail -2"
 
 rhel7stig_time_service: chronyd
 rhel7stig_time_service_configs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -279,6 +279,11 @@ rhel7stig_av_package:
         - clamav-server
     service: clamav-daemon
 
+# RHEL-07-032010
+# How to check if your definitions are up to date. Passed to an Ansible
+# shell task, and that task's stdout_lines will be printed in a debug task.
+rhel7stig_av_status_command: "savlog | grep 'Successfully updated' | tail -2"
+
 rhel7stig_time_service: chronyd
 rhel7stig_time_service_configs:
     chronyd:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -282,7 +282,7 @@ rhel7stig_av_package:
 # RHEL-07-032010
 # How to check if your definitions are up to date. Passed to an Ansible
 # shell task, and that task's stdout_lines will be printed in a debug task.
-rhel7stig_av_status_command: "ls -l $(grep -i '^DatabaseDirectory' /etc/clamav.conf | awk '{print $NF}')/*.cvd"
+rhel7stig_av_status_command: "true"
 # For ClamAV: "ls -l $(grep -i '^DatabaseDirectory' /etc/clamav.conf | awk '{print $NF}')/*.cvd"
 # For McAfee: "ls -l /opt/NAI/LinuxShield/engine/dat/*.dat"
 # For Sophos: "/opt/sophos-av/bin/savlog | grep 'Successfully updated' | tail -2"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1325,13 +1325,21 @@
       - RHEL-07-031010
       - rsyslog
 
-- name: "MEDIUM | RHEL-07-032010 | PATCH | The system must update the DoD-approved virus scan program every seven days or more frequently."
-  command: "true"
-  changed_when: no
+- name: "MEDIUM | RHEL-07-032010 | AUDIT | The system must update the DoD-approved virus scan program every seven days or more frequently."
+  block:
+    - name: "MEDIUM | RHEL-07-032010 | AUDIT | The system must update the DoD-approved virus scan program every seven days or more frequently."
+      shell: "{{ rhel7stig_av_status_command }}"
+      changed_when: no
+      check_mode: no
+      register: rhel_07_032010_audit
+
+    - name: "MEDIUM | RHEL-07-032010 | AUDIT | The system must update the DoD-approved virus scan program every seven days or more frequently."
+      debug:
+        msg: "{{ rhel_07_032010_audit.stdout_lines }}"
+
   when: rhel_07_032010
   tags:
       - RHEL-07-032010
-      - notimplemented
 
 - name: "MEDIUM | RHEL-07-040100 | PATCH | The host must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the Ports, Protocols, and Services Management Component Local Service Assessment (PPSM CLSA) and vulnerability assessments."
   command: "true"


### PR DESCRIPTION
Can remove the `savlog` command, but all sites would have to set it to their preferred command. If someone can tell me what the CLAM equivalent would be, I can edit the default.