### PR TITLE
limits.conf: avoid replacing comment lines

### DIFF
--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -93,8 +93,8 @@
     state: present
     dest: /etc/security/limits.conf
     insertbefore: '^# End of file'
-    regexp: '^#?\\*.*maxlogins'
-    line: '*           hard    maxlogins     {{ rhel7stig_maxlogins }}'
+    regexp: '^\*.*maxlogins'
+    line: '*               hard    maxlogins       {{ rhel7stig_maxlogins }}'
   when: rhel_07_040000
   tags:
       - RHEL-07-040000


### PR DESCRIPTION
also fixed whitespace to be consistent with examples in default limits.conf