### PR TITLE
Fixing 122

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,7 +465,7 @@ rhel7stig_audit_disk_size_query: "[?mount=='{{ rhel7stig_audit_part }}'].size_to
 rhel7stig_auditd_mail_acct: root
 
 # RHEL-07-020630
-rhel7stig_homedir_mode: 0700
+rhel7stig_homedir_mode: 0750
 
 # RHEL-07-031000
 # rhel7stig_log_aggregation_server: logagg.example.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,7 +465,7 @@ rhel7stig_audit_disk_size_query: "[?mount=='{{ rhel7stig_audit_part }}'].size_to
 rhel7stig_auditd_mail_acct: root
 
 # RHEL-07-020630
-rhel7stig_homedir_mode: 0750
+rhel7stig_homedir_mode: 0700
 
 # RHEL-07-031000
 # rhel7stig_log_aggregation_server: logagg.example.com

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -713,11 +713,25 @@
       - RHEL-07-020620
 
 - name: "MEDIUM | RHEL-07-020630 | PATCH | All local interactive user home directories must have mode 0750 or less permissive."
-  file:
-    path: "{{ item.split(':')[2] }}"
-    mode: "{{ rhel7stig_homedir_mode }}"
-    state: directory
-  with_items: "{{ rhel7stig_passwd_homedir_audit.stdout_lines }}"
+  block:
+    - name: "MEDIUM | RHEL-07-020630 | AUDIT | All local interactive user home directories must have mode 0750 or less permissive."
+      stat:
+        path: "{{ item.split(':')[2] }}"
+      register: rhel_07_020630_audit
+      with_items: "{{ rhel7stig_passwd_homedir_audit.stdout_lines }}"
+
+    - name: "MEDIUM | RHEL-07-020630 | PATCH | All local interactive user home directories must have mode 0750 or less permissive."
+      file:
+        path: "{{ item.stat.path }}"
+        mode: "{{ rhel7stig_homedir_mode }}"
+        state: directory
+      with_items: "{{ rhel_07_020630_audit.results }}"
+      when:
+        - item.stat.wgrp or
+          item.stat.roth or
+          item.stat.woth or
+          item.stat.xoth
+
   when: rhel_07_020630
   tags:
       - RHEL-07-020630

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -718,6 +718,11 @@
       stat:
         path: "{{ item.split(':')[2] }}"
       register: rhel_07_020630_audit
+      changed_when:
+        - rhel_07_020630_audit.stat.wgrp or
+          rhel_07_020630_audit.stat.roth or
+          rhel_07_020630_audit.stat.woth or
+          rhel_07_020630_audit.stat.xoth
       with_items: "{{ rhel7stig_passwd_homedir_audit.stdout_lines }}"
 
     - name: "MEDIUM | RHEL-07-020630 | PATCH | All local interactive user home directories must have mode 0750 or less permissive."
@@ -726,11 +731,7 @@
         mode: "{{ rhel7stig_homedir_mode }}"
         state: directory
       with_items: "{{ rhel_07_020630_audit.results }}"
-      when:
-        - item.stat.wgrp or
-          item.stat.roth or
-          item.stat.woth or
-          item.stat.xoth
+      when: item | changed
 
   when: rhel_07_020630
   tags:


### PR DESCRIPTION
Only setting permissions if the home directory's stat results indicate group `w` or other `rwx`.