### PR TITLE
Fix 121

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,7 +465,7 @@ rhel7stig_audit_disk_size_query: "[?mount=='{{ rhel7stig_audit_part }}'].size_to
 rhel7stig_auditd_mail_acct: root
 
 # RHEL-07-020630
-rhel7stig_homedir_mode: 0700
+rhel7stig_homedir_mode: 0750
 
 # RHEL-07-031000
 # rhel7stig_log_aggregation_server: logagg.example.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -465,7 +465,7 @@ rhel7stig_audit_disk_size_query: "[?mount=='{{ rhel7stig_audit_part }}'].size_to
 rhel7stig_auditd_mail_acct: root
 
 # RHEL-07-020630
-rhel7stig_homedir_mode: 0750
+rhel7stig_homedir_mode: 0700
 
 # RHEL-07-031000
 # rhel7stig_log_aggregation_server: logagg.example.com

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -876,8 +876,7 @@
   lineinfile:
     path: /etc/rsyslog.conf
     state: present
-    regexp: 'cron.\*'
-    line: 'cron.* /var/log/cron.log'
+    line: 'cron.*                                                  /var/log/cron'
     insertafter: '#### RULES ####'
   register: result
   failed_when:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -876,6 +876,7 @@
   lineinfile:
     path: /etc/rsyslog.conf
     state: present
+    regexp: '^cron\.\*[ \t]+/var/log/cron$'
     line: 'cron.*                                                  /var/log/cron'
     insertafter: '#### RULES ####'
   register: result


### PR DESCRIPTION
Leaves the default cron syslog location alone. If there's a clever way to ensure that we don't modify an otherwise `cron.*` line pointing to a different file, I'm all for it.