### PR TITLE
Implementing RHEL-07-021000

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -869,6 +869,7 @@
     src: "{{ ansible_mounts | json_query('[?mount == `/home`] | [0].device') }}"
     fstype: "{{ ansible_mounts | json_query('[?mount == `/home`] | [0].fstype') }}"
     opts: "{{ ansible_mounts | json_query('[?mount == `/home`] | [0].options') }},nosuid"
+    state: mounted
   when:
     - rhel_07_021000
     - ansible_mounts | selectattr('mount', 'match', '^/home$') | list | length != 0

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -864,12 +864,17 @@
       - RHEL-07-020900
 
 - name: "MEDIUM | RHEL-07-021000 | PATCH | File systems that contain user home directories must be mounted to prevent files with the setuid and setgid bit set from being executed."
-  command: "true"
-  changed_when: no
-  when: rhel_07_021000
+  mount:
+    path: /home
+    src: "{{ ansible_mounts | json_query('[?mount == `/home`] | [0].device') }}"
+    fstype: "{{ ansible_mounts | json_query('[?mount == `/home`] | [0].fstype') }}"
+    opts: "{{ ansible_mounts | json_query('[?mount == `/home`] | [0].options') }},nosuid"
+  when:
+    - rhel_07_021000
+    - ansible_mounts | selectattr('mount', 'match', '^/home$') | list | length != 0
+    - "'nosuid' not in (ansible_mounts | json_query('[?mount == `/home`] | [0].options'))"
   tags:
-      - RHEL-07-021000
-      - notimplemented
+    - RHEL-07-021000
 
 - name: "MEDIUM | RHEL-07-021010 | PATCH | File systems that are used with removable media must be mounted to prevent files with the setuid and setgid bit set from being executed."
   command: "true"


### PR DESCRIPTION
If `nosuid` is missing from `/home` mount options, and `/home` is a separate filesystem, add `nosuid` to the current mount options.

This may change the `/home` options even if it's NFS-mounted, which falls under 021020. But there's no distinction made in 021000 for the type of filesystem. Since the only way to avoid a finding on 021000 (if applicable) is to have `/home` be a part of `/`, I'm reading this as "add the `nosuid` option to `/home`, regardless of its physical location".