### PR TITLE
rewrite deprecated jinja tests used as filters

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -237,7 +237,7 @@
         check_mode: no
         changed_when: no
         failed_when: rhel_07_021350_grub_cmdline_linux_audit.rc > 1
-        when: rhel_07_021350_default_grub_missing_audit | changed
+        when: rhel_07_021350_default_grub_missing_audit is changed
         register: rhel_07_021350_grub_cmdline_linux_audit
 
       - name: "HIGH | RHEL-07-021350 | PATCH | Copy over a sane /etc/default/grub"
@@ -249,7 +249,7 @@
             mode: 0644
         vars:
             grub_cmdline_linux: "{{ rhel_07_021350_grub_cmdline_linux_audit.stdout }}"
-        when: rhel_07_021350_default_grub_missing_audit | changed
+        when: rhel_07_021350_default_grub_missing_audit is changed
 
       - name: "HIGH | RHEL-07-021350 | PATCH | fips=1 must be in /etc/default/grub"
         replace:
@@ -263,7 +263,7 @@
             append: yes  # this is the default
         when:
             - not ansible_check_mode or
-              not rhel_07_021350_default_grub_missing_audit | changed
+              rhel_07_021350_default_grub_missing_audit is not changed
         notify: make grub2 config
 
       - name: "HIGH | RHEL-07-021350 | PATCH | If /boot or /boot/efi reside on separate partitions, the kernel parameter boot=<partition> must be added to the kernel command line."
@@ -282,7 +282,7 @@
         when:
             - rhel7stig_boot_part not in ['/', '']
             - not ansible_check_mode or
-              not rhel_07_021350_default_grub_missing_audit | changed
+              rhel_07_021350_default_grub_missing_audit is not changed
         notify: make grub2 config
         register: result
 
@@ -297,14 +297,14 @@
         register: rhel_07_021350_audit
         when:
             - not ansible_check_mode or
-              not rhel_07_021350_default_grub_missing_audit | changed
+              rhel_07_021350_default_grub_missing_audit is not changed
             - rhel7stig_boot_part not in ['/', ''] or
               'boot=' not in item
         changed_when:
             - ansible_check_mode
-            - rhel_07_021350_audit | failed
+            - rhel_07_021350_audit is failed
         failed_when:
-            - rhel_07_021350_audit | failed
+            - rhel_07_021350_audit is failed
             - not ansible_check_mode or
               rhel_07_021350_audit.rc > 1
   when: rhel_07_021350
@@ -364,7 +364,7 @@
   notify: restart sshd
   when:
       - rhel_07_040390
-      - not ansible_distribution_version | version_compare('7.4', '>=')
+      - ansible_distribution_version is not version_compare('7.4', '>=')
   tags:
       - RHEL-07-040390
       - ssh

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -691,7 +691,7 @@
         include_tasks: parse_etc_passwd.yml
         vars:
             rhel7stig_passwd_tasks: "RHEL-07-020270"
-        when: rhel_07_020270_patch | changed
+        when: rhel_07_020270_patch is changed
   when: rhel_07_020270
   tags:
       - RHEL-07-020270
@@ -799,7 +799,7 @@
             mode: "{{ rhel7stig_homedir_mode }}"
             state: directory
         with_items: "{{ rhel_07_020630_audit.results }}"
-        when: item | changed
+        when: item is changed
 
   when: rhel_07_020630
   tags:
@@ -854,7 +854,7 @@
         loop_control:
             label: "{{ rhel7stig_passwd_label }}"
         when:
-            - item | changed
+            - item is changed
         vars:
             this_item: "{{ item.item }}"
   vars:
@@ -896,7 +896,7 @@
         loop_control:
             label: "{{ rhel7stig_passwd_label }}"
         when:
-            - item | changed
+            - item is changed
         vars:
             this_item: "{{ item.item.item }}"
             this_result: "{{ item.item }}"
@@ -937,7 +937,7 @@
         loop_control:
             label: "{{ rhel7stig_passwd_label }}"
         when:
-            - item | changed
+            - item is changed
         vars:
             this_item: "{{ item.item }}"
   vars:
@@ -969,7 +969,7 @@
         loop_control:
             label: "{{ rhel7stig_passwd_label }}"
         when:
-            - item | changed
+            - item is changed
         vars:
             this_item: "{{ item.item }}"
   vars:
@@ -1107,7 +1107,7 @@
       insertafter: '#### RULES ####'
   register: result
   failed_when:
-      - result | failed
+      - result is failed
       - result.rc != 257
   when: rhel_07_021100
   tags:
@@ -1249,7 +1249,7 @@
       line: "space_left_action = email"
   register: rhel7stig_auditd_space_left_action_result
   failed_when:
-      - rhel7stig_auditd_space_left_action_result | failed
+      - rhel7stig_auditd_space_left_action_result is failed
       - rhel7stig_auditd_space_left_action_result.rc != 257
   when: rhel_07_030340
   tags:
@@ -1262,7 +1262,7 @@
       line: "action_mail_acct = {{ rhel7stig_auditd_mail_acct }}"
   register: rhel7stig_auditd_action_mail_acct_result
   failed_when:
-      - rhel7stig_auditd_action_mail_acct_result | failed
+      - rhel7stig_auditd_action_mail_acct_result is failed
       - rhel7stig_auditd_action_mail_acct_result.rc != 257
   when: rhel_07_030350
   tags:
@@ -1561,7 +1561,7 @@
       insertafter: EOF
   register: result
   failed_when:
-      - result | failed
+      - result is failed
       - result.rc != 257
   when:
       - rhel_07_031000
@@ -1585,7 +1585,7 @@
       - not rhel7stig_system_is_log_aggregator
   register: result
   failed_when:
-      - result | failed
+      - result is failed
       - result.rc != 257
   tags:
       - RHEL-07-031010
@@ -1764,7 +1764,7 @@
   notify: restart sshd
   when:
       - rhel_07_040340
-      - not ansible_distribution_version | version_compare('7.4', '>=') or
+      - ansible_distribution_version is not version_compare('7.4', '>=') or
         rhel7stig_workaround_for_disa_benchmark or
         rhel7stig_workaround_for_ssg_benchmark
   tags:
@@ -2146,7 +2146,7 @@
       state: present
   register: result
   failed_when:
-      - result | failed
+      - result is failed
       - result.rc != 257
   when:
       - rhel7stig_tftp_required

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Check OS version and family
   assert:
-      that: ansible_os_family == 'RedHat' and ansible_distribution_major_version | version_compare('7', '==')
+      that: ansible_os_family == 'RedHat' and ansible_distribution_major_version is version_compare('7', '==')
       msg: "This role can only be run against RHEL/CENTOS 7. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
   tags:
       - always
 
 - name: Check ansible version
   assert:
-      that: ansible_version.full | version_compare(rhel7stig_min_ansible_version, '>=')
+      that: ansible_version.full is version_compare(rhel7stig_min_ansible_version, '>=')
       msg: You must use Ansible {{ rhel7stig_min_ansible_version }} or greater
   tags:
       - always


### PR DESCRIPTION
Starting in ansible 2.5, the use of jinja tests as filters has been
deprecated.
https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters

This change keeps the syntax compatible with ansible 2.4 while fixing
the deprecation errors that would otherwise appear when running the
role under ansible 2.5+.

I've tested these changes against ansible versions 2.5.0-2.el7 and 2.4.2.0-2.el7