### PR TITLE
Proof-of-concept: handling of disruptive and complex tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
     # Test role idempotence.
     - idempotence_log=$(mktemp)
 
-    - docker exec --tty $container_id ansible-playbook /etc/ansible/roles/role_under_test/tests/travis.yml --extra-vars "@/etc/ansible/roles/role_under_test/tests/extra_vars_travis.yml" -vv | tee -a $idempotence_log
+    - docker exec --tty $container_id ansible-playbook /etc/ansible/roles/role_under_test/tests/travis.yml --extra-vars "@/etc/ansible/roles/role_under_test/tests/extra_vars_travis.yml" --extra-vars "@/etc/ansible/roles/role_under_test/tests/extra_vars_travis_idempotence.yml" -vv | tee -a $idempotence_log
     - >
       tail $idempotence_log
       | grep -q "changed=0.*failed=0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,7 @@ rhel_07_020210: true
 rhel_07_020220: true
 rhel_07_020230: true
 # Not an automated task
-rhel_07_020250: false
+rhel_07_020250: true
 rhel_07_020310: true
 rhel_07_021350: true
 rhel_07_021710: true
@@ -281,6 +281,14 @@ rhel_07_040600: true
 
 # Whether or not to run tasks related to auditing/patching the desktop environment
 rhel7stig_gui: no
+
+# RHEL-07-020250
+# This is a check for a "supported release"
+# These are the minimum supported releases.
+# (Red Hat has support for older versions if you pay extra for it.)
+rhel7stig_min_supported_os_ver:
+    RedHat: "7.5"
+    CentOS: "7.4.1708"
 
 # RHEL-07-040740
 # If system is not router, run tasks that disable router functions.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,25 @@ rhel7stig_cat1_patch: yes
 rhel7stig_cat2_patch: yes
 rhel7stig_cat3_patch: yes
 
+# We've defined complexity-high to mean that we cannot automatically remediate
+# the rule in question.  In the future this might mean that the remediation
+# may fail in some cases.
+rhel7stig_complexity_high: no
+
+# Show "changed" for complex items not remediated per complexity-high setting
+# to make them stand out.  "changed" items on a second run of the role would
+# indicate items requiring manual review.
+rhel7stig_audit_complex: yes
+
+# We've defined disruption-high to indicate items that are likely to cause
+# disruption in a normal workflow.  These items can be remediated automatically
+# but are disabled by default to avoid disruption.
+rhel7stig_disruption_high: no
+
+# Show "changed" for disruptive items not remediated per disruption-high
+# setting to make them stand out.
+rhel7stig_audit_disruptive: yes
+
 rhel7stig_skip_for_travis: false
 
 rhel7stig_workaround_for_disa_benchmark: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ rhel_07_020010: true
 rhel_07_020050: true
 rhel_07_020060: true
 # This check breaks with redhat.com repos as they do not sign repo data
-rhel_07_020070: false
+rhel_07_020070: "{{ ansible_distribution == 'CentOS' }}"
 rhel_07_020210: true
 rhel_07_020220: true
 rhel_07_020230: true

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -186,6 +186,18 @@
 
 # RHEL-07-020250 | PATCH | The operating system must be a supported release."
 # Not automated since current end of life for RHEL 7 is 2024-06-30
+- name: "HIGH | RHEL-07-020250 | PATCH | The operating system must be a vendor supported release."
+  debug:
+      msg: Minimum supported version of {{ ansible_distribution }} is {{ rhel7stig_min_supported_os_ver[ansible_distribution] }}
+  changed_when:
+      - rhel7stig_audit_complex
+      - ansible_distribution_version is not version_compare(rhel7stig_min_supported_os_ver[ansible_distribution], '>=')
+  when:
+      - rhel_07_020250
+      - rhel7stig_complex
+  tags:
+      - RHEL-07-020250
+      - complexity-high
 
 - block:
       # Currently just locks user account

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -150,9 +150,13 @@
       regexp: repo_gpgcheck
       line: repo_gpgcheck=1
       insertafter: '\[main\]'
-  when: rhel_07_020070
+  check_mode: "{{ rhel7stig_complex_check_mode }}"
+  when:
+      - rhel_07_020070
+      - rhel7stig_disruptive
   tags:
       - RHEL-07-020070
+      - disruption-high
       - yum
 
 - name: |

--- a/tests/extra_vars_travis.yml
+++ b/tests/extra_vars_travis.yml
@@ -5,6 +5,9 @@ rhel7stig_cat3_patch: yes
 
 rhel7stig_skip_for_travis: true
 
+# we're not worried about disrupting CI, plus it's good to test all tasks
+rhel7stig_audit_disruptive: true
+
 rhel7stig_antivirus_required: no
 
 # Potential for locking out users - doesn't matter during CI

--- a/tests/extra_vars_travis_idempotence.yml
+++ b/tests/extra_vars_travis_idempotence.yml
@@ -1,0 +1,3 @@
+---
+rhel7stig_audit_complex: no
+rhel7stig_audit_disruptive: no

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,17 @@
 ---
 rhel7stig_min_ansible_version: 2.4
 
+# these variables are for enabling tasks to run that will be further controled
+# by check_mode to prevent the remediation task from making changes as
+# requested
+rhel7stig_complex: "{{ rhel7stig_complexity_high or rhel7stig_audit_complex }}"
+rhel7stig_disruptive: "{{ rhel7stig_disruption_high or rhel7stig_audit_disruptive }}"
+
+# These vars are made to go in the check_mode property of a task that is
+# complex or disruptive, respectively.
+rhel7stig_complex_check_mode: "{{ ansible_check_mode or rhel7stig_audit_complex }}"
+rhel7stig_disruptive_check_mode: "{{ ansible_check_mode or rhel7stig_audit_disruptive }}"
+
 # this allows us to insert a name=value into a line of the format:
 # key="name1=value1 name2=value2 nameN=valueN"
 rhel7stig_regexp_quoted_params: ^({{ rhel7stig_re_qp_key }})({{ rhel7stig_re_qp_other_params }})({{


### PR DESCRIPTION
This starts implementation of the proposal I made in https://github.com/MindPointGroup/RHEL7-STIG/issues/119#issuecomment-381254864

This implements the complexity-high and distruption-high concepts, vars, and tags, with an example of each.

Proposal quoted:

> Here's my proposal.
> The scap-security-guide project labels their remediation tasks with 3 categories: severity, complexity, and disruption.  It seems like a good approach to me:
> 
> - I suggest we tag items requiring manual review as `complexity-high` and add a conditional on `rhel7stig_complexity_high: default(no)`.
> - I suggest we tag items that can break a system as `disruption-high` and add a conditional on `rhel7stig_disruption_high: default(no)`.
> 
> We can then add later `disruption-medium` and `disruption-low` for tasks that are respectively less likely to break something.  Similarly, later add `complexity-medium` and `complexity-low` for tasks depending on how involved the remediation is.  (Specifically, I'm thinking that if, e.g., a remediation requires multiple tasks to succeed, it would get `complexity-medium`.)
> 
> Edit: @shepdelacreme yes, I'd also like to add something like `rhel7stig_audit_complex` and `rhel7stig_audit_disruptive` as an available hint to the user that something was not remediated.