### PR TITLE
Fix incorrect comments for grub

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -354,7 +354,7 @@ rhel7stig_kdump_required: false
 # Set the SNMP community string to this from the default of public or private
 rhel7stig_snmp_community: Endgam3Ladyb0g
 
-# RHEL-07-010460 and RHEL-07-010470
+# RHEL-07-010480 and RHEL-07-010490
 # Password protect the boot loader
 rhel7stig_bootloader_password: 'Boot1tUp!'
 rhel7stig_boot_superuser: root


### PR DESCRIPTION
From tasks/fix-cat1.yml:
```- name: |

      "HIGH | RHEL-07-010480 | PATCH | Systems with a Basic Input/Output System (BIOS) must require authentication upon booting into single-user and maintenance m
odes."
      "HIGH | RHEL-07-010490 | PATCH | Systems using Unified Extensible Firmware Interface (UEFI) must require authentication upon booting into single-user and ma
intenance modes."
  lineinfile:
      dest: /etc/grub.d/40_custom
      insertafter: EOF
      regexp: "{{ item.regexp }}"
      line: "{{ item.line }}"
  with_items: "{{ rhel7stig_boot_password_config }}"
  notify: make grub2 config
  when: rhel_07_010480 or rhel_07_010490 <<<<<<<<<<
  tags:
      - RHEL-07-010480
      - RHEL-07-010490
      - grub
      - bootloader
```