### PR TITLE
Fix FIPS for EFI systems, et al.

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -7,7 +7,6 @@
         check_mode: no
         failed_when: no
         changed_when: no
-        ignore_errors: yes
         register: rhel_07_010010_audit
 
       - name: "HIGH | RHEL-07-010010 | PATCH | The file permissions, ownership, and group membership of system files and commands must match the vendor values."
@@ -26,7 +25,6 @@
         check_mode: no
         failed_when: no
         changed_when: no
-        ignore_errors: yes
         register: rhel_07_010020_audit
 
       - name: "HIGH | RHEL-07-010020 | PATCH | The cryptographic hash of system files and commands must match vendor values."
@@ -206,7 +204,6 @@
         check_mode: no
         changed_when: no
         failed_when: no
-        ignore_errors: yes
         register: rhel_07_020310_audit
 
       - name: "HIGH | RHEL-07-020310 | PATCH | The root account must be the only account having unrestricted access to the system"
@@ -462,7 +459,6 @@
         check_mode: no
         failed_when: no
         changed_when: no
-        ignore_errors: yes
         with_items:
             - public
             - private

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1272,6 +1272,7 @@
   block:
       - name: "MEDIUM | RHEL-07-030360 | AUDIT | All privileged function executions must be audited. (find suid/sgid programs)"
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -type f ( -perm -4000 -o -perm -2000 )
+        check_mode: no
         changed_when: no
         register: rhel_07_030360_audit
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -153,7 +153,6 @@
       hidden: true
   failed_when: no
   changed_when: no
-  ignore_errors: yes
   register: rhel_07_040410_audit
   when: rhel_07_040410
   tags:
@@ -171,7 +170,6 @@
       hidden: true
   failed_when: no
   changed_when: no
-  ignore_errors: yes
   register: rhel_07_040420_audit
   when: rhel_07_040420
   tags:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -1,6 +1,7 @@
 ---
 - name: "PRELIM | Find all sudoers files."
   command: "find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'"
+  check_mode: no
   changed_when: no
   failed_when: no
   register: rhel7stig_sudoers_files

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -97,7 +97,7 @@
       - RHEL-07-031010
 
 - name: "PRELIM | RHEL-07-021350 | Check if /boot or /boot/efi reside on separate partitions"
-  shell: df --output=target /boot/efi | tail -n 1
+  shell: df --output=target /boot | tail -n 1
   changed_when: no
   check_mode: no
   register: rhel_07_boot_part


### PR DESCRIPTION
boot= needs to point to /boot, not /boot/efi.  The STIG says to point to /boot/efi, which breaks system boot.

2 other minor items included.