### PR TITLE
Change yum group to x11 id value

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2154,10 +2154,10 @@
   tags:
       - RHEL-07-040720
 
-- name: "MEDIUM | RHEL-07-040730 | PATCH | An X Windows display manager must not be installed unless approved."
+- name: "MEDIUM | RHEL-07-040730 | PATCH | An X Window display manager must not be installed unless approved."
   yum:
       name:
-          - "@X Windows System"
+          - "@x11"
           - xorg-x11-server-common
       state: absent
   when:


### PR DESCRIPTION
There is variation in the groupname, change to id referral to remove variation
    `yum grouplist hidden id | grep X`
      `X Window System (x11)`
      `Legacy UNIX Compatibility (legacy-unix)`
      `Legacy X Window System Compatibility (legacy-x)`