### PR TITLE
feature: run role in a chroot environment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ rhel7stig_skip_for_travis: false
 rhel7stig_workaround_for_disa_benchmark: true
 rhel7stig_workaround_for_ssg_benchmark: true
 
+# tweak role to run in a chroot, such as in kickstart %post script
+rhel7stig_system_is_chroot: no
+
 # These variables correspond with the STIG IDs defined in the STIG and allows you to enable/disable specific rules.
 # PLEASE NOTE: These work in coordination with the cat1, cat2, cat3 group variables. You must enable an entire group
 # in order for the variables below to take effect.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,8 @@
   service:
       name: sshd
       state: restarted
+  when:
+      - not rhel7stig_system_is_chroot
 
 - name: reboot system
   shell: sleep 3; reboot
@@ -13,6 +15,8 @@
   service:
       name: snmpd
       state: restarted
+  when:
+      - not rhel7stig_system_is_chroot
 
 - name: make grub2 config
   command: /usr/sbin/grub2-mkconfig --output={{ rhel7stig_grub_cfg_path }}
@@ -23,6 +27,8 @@
   service:
       name: "{{ rhel7stig_time_service }}"
       state: restarted
+  when:
+      - not rhel7stig_system_is_chroot
 
 - name: restart auditd
   command: /usr/sbin/service auditd restart
@@ -30,6 +36,7 @@
       warn: no
   when:
       - rhel7stig_skip_for_travis == false
+      - not rhel7stig_system_is_chroot
 
 - name: rebuild initramfs
   command: dracut -f

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -342,7 +342,7 @@
       - name: "HIGH | RHEL-07-030000 | PATCH | Auditing must be configured to produce records containing information to establish what type of events occurred, where the events occurred, the source of the events, and the outcome of the events. These audit records must also identify individual identities of group account users."
         service:
             name: auditd
-            state: started
+            state: "{{ rhel7stig_service_started }}"
             enabled: yes
   when: rhel_07_030000
   tags:
@@ -358,7 +358,7 @@
       - name: "HIGH | RHEL-07-032000 | PATCH | The system must use a DoD-approved virus scan program."
         service:
             name: "{{ rhel7stig_av_package.service }}"
-            state: started
+            state: "{{ rhel7stig_service_started }}"
             enabled: yes
         ignore_errors: yes
   when:

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -158,12 +158,12 @@
       - yum
 
 - name: |
-
       "HIGH | RHEL-07-020210 | PATCH | The operating system must enable SELinux."
       "HIGH | RHEL-07-020220 | PATCH | The operating system must enable the SELinux targeted policy."
   selinux:
       state: enforcing
       policy: targeted
+  check_mode: "{{ ansible_check_mode or rhel7stig_system_is_chroot }}"
   when: rhel_07_020210 or rhel_07_020220
   tags:
       - RHEL-07-020210

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -661,7 +661,7 @@
         service:
             name: yum-cron
             enabled: "{{ rhel7stig_auto_package_updates.enabled }}"
-            state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary('started','stopped')}}"
+            state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary(rhel7stig_service_started, 'stopped')}}"
         when: rhel_07_020260_yumcron_service_status.stdout == "loaded"
 
   when: rhel_07_020260
@@ -1756,7 +1756,7 @@
 - name: "MEDIUM | RHEL-07-040310 | PATCH | All networked systems must use SSH for confidentiality and integrity of transmitted and received information as well as information during preparation for transmission."
   service:
       name: sshd
-      state: started
+      state: "{{ rhel7stig_service_started }}"
       enabled: yes
   when: rhel_07_040310
   tags:
@@ -2036,7 +2036,7 @@
 - name: "MEDIUM | RHEL-07-040520 | PATCH | The system must use a local firewall."
   service:
       name: "{{ rhel7stig_firewall_service }}"
-      state: started
+      state: "{{ rhel7stig_service_started }}"
       enabled: yes
   when: rhel_07_040520
   tags:

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -80,7 +80,7 @@
 - name: "LOW | RHEL-07-021340 | PATCH | The system must use a separate file system for /tmp (or equivalent)."
   systemd:
       name: tmp.mount
-      daemon_reload: yes
+      daemon_reload: "{{ rhel7stig_systemd_daemon_reload }}"
       enabled: yes
       masked: no
       state: "{{ rhel7stig_service_started }}"

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -83,7 +83,7 @@
       daemon_reload: yes
       enabled: yes
       masked: no
-      state: started
+      state: "{{ rhel7stig_service_started }}"
   when: rhel_07_021340
   tags:
       - RHEL-07-021340

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 rhel7stig_min_ansible_version: 2.4
 
 rhel7stig_service_started: "{{ rhel7stig_system_is_chroot | ternary(omit, 'started') }}"
+rhel7stig_systemd_daemon_reload: "{{ not rhel7stig_system_is_chroot }}"
 
 # these variables are for enabling tasks to run that will be further controled
 # by check_mode to prevent the remediation task from making changes as

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 rhel7stig_min_ansible_version: 2.4
 
+rhel7stig_service_started: "{{ rhel7stig_system_is_chroot | ternary(omit, 'started') }}"
+
 # these variables are for enabling tasks to run that will be further controled
 # by check_mode to prevent the remediation task from making changes as
 # requested


### PR DESCRIPTION
In conjunction with #161, these changes allow the role to successfully run in a kickstart "%post" script to STIG a system at provisioning time.