### PR TITLE
feature: unprivileged container support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ rhel7stig_workaround_for_ssg_benchmark: true
 # tweak role to run in a chroot, such as in kickstart %post script
 rhel7stig_system_is_chroot: no
 
+# tweak role to run in a non-privileged container
+rhel7stig_system_is_container: no
+
 # These variables correspond with the STIG IDs defined in the STIG and allows you to enable/disable specific rules.
 # PLEASE NOTE: These work in coordination with the cat1, cat2, cat3 group variables. You must enable an entire group
 # in order for the variables below to take effect.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -37,6 +37,7 @@
   when:
       - rhel7stig_skip_for_travis == false
       - not rhel7stig_system_is_chroot
+      - not rhel7stig_system_is_container
 
 - name: rebuild initramfs
   command: dracut -f

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,6 +22,7 @@
   command: /usr/sbin/grub2-mkconfig --output={{ rhel7stig_grub_cfg_path }}
   when:
       - not rhel7stig_skip_for_travis
+      - not rhel7stig_system_is_container
 
 - name: "restart {{ rhel7stig_time_service }}"
   service:

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -197,7 +197,9 @@
       state: enforcing
       policy: targeted
   check_mode: "{{ ansible_check_mode or rhel7stig_system_is_chroot }}"
-  when: rhel_07_020210 or rhel_07_020220
+  when:
+      - rhel_07_020210 or rhel_07_020220
+      - not rhel7stig_system_is_container
   tags:
       - RHEL-07-020210
       - RHEL-07-020220

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -379,6 +379,8 @@
             name: auditd
             state: "{{ rhel7stig_service_started }}"
             enabled: yes
+        when:
+            - not rhel7stig_system_is_container
   when: rhel_07_030000
   tags:
       - RHEL-07-030000

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2116,6 +2116,9 @@
       name: "{{ rhel7stig_firewall_service }}"
       state: "{{ rhel7stig_service_started }}"
       enabled: yes
+  # XXX: fix this.  The above task should work just fine in a chroot, but
+  # fails for some reason when the chroot is also a container.
+  ignore_errors: "{{ rhel7stig_system_is_chroot and rhel7stig_system_is_container }}"
   when: rhel_07_040520
   tags:
       - RHEL-07-040520

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1752,7 +1752,7 @@
       name: kernel.randomize_va_space
       value: 2
       state: present
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       sysctl_set: yes
       ignoreerrors: yes
   when: rhel_07_040201
@@ -2126,7 +2126,7 @@
       name: net.ipv4.conf.all.accept_source_route
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040610
   tags:
@@ -2138,7 +2138,7 @@
       name: net.ipv4.conf.default.accept_source_route
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040620
   tags:
@@ -2151,7 +2151,7 @@
       state: present
       value: 1
       sysctl_set: yes
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040630
   tags:
@@ -2163,7 +2163,7 @@
       name: net.ipv4.conf.default.accept_redirects
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040640
   tags:
@@ -2175,7 +2175,7 @@
       name: net.ipv4.conf.all.accept_redirects
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040641
   tags:
@@ -2187,7 +2187,7 @@
       name: net.ipv4.conf.default.send_redirects
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040650
   tags:
@@ -2199,7 +2199,7 @@
       name: net.ipv4.conf.all.send_redirects
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040660
   tags:
@@ -2284,7 +2284,7 @@
       name: net.ipv4.ip_forward
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when:
       - not rhel7stig_system_is_router
@@ -2323,7 +2323,7 @@
       name: net.ipv6.conf.all.accept_source_route
       state: present
       value: 0
-      reload: yes
+      reload: "{{ rhel7stig_sysctl_reload }}"
       ignoreerrors: yes
   when: rhel_07_040830
   tags:

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -84,6 +84,9 @@
       enabled: yes
       masked: no
       state: "{{ rhel7stig_service_started }}"
+  # XXX: fix this.  The above task should work just fine in a chroot, but
+  # fails for some reason when the chroot is also a container.
+  ignore_errors: "{{ rhel7stig_system_is_chroot and rhel7stig_system_is_container }}"
   when: rhel_07_021340
   tags:
       - RHEL-07-021340

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,7 @@ rhel7stig_min_ansible_version: 2.4
 
 rhel7stig_service_started: "{{ rhel7stig_system_is_chroot | ternary(omit, 'started') }}"
 rhel7stig_systemd_daemon_reload: "{{ not rhel7stig_system_is_chroot }}"
+rhel7stig_sysctl_reload: "{{ not rhel7stig_system_is_container }}"
 
 # these variables are for enabling tasks to run that will be further controled
 # by check_mode to prevent the remediation task from making changes as


### PR DESCRIPTION
after these changes, the role can be run on unprivileged containers running systemd (such as the rhel7-init container) by setting:
```
rhel7stig_system_is_container: yes
```

The role can also be run on unprivileged non-systemd-running containers by additionally setting:
```
rhel7stig_system_is_chroot: yes
```