### PR TITLE
Fixes deprecation warnings that are associated with loops using yum

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -200,11 +200,10 @@
 
 - name: "PRELIM | RHEL-07-020210 RHEL-07-020220| Install SELinux related dependencies"
   yum:
-      name: "{{ item }}"
-  with_items:
-      - libselinux-python
-      - selinux-policy-targeted
-      - selinux-policy-mls
+      name:
+        - libselinux-python
+        - selinux-policy-targeted
+        - selinux-policy-mls
   when:
       - rhel_07_020210 or rhel_07_020220
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -201,9 +201,9 @@
 - name: "PRELIM | RHEL-07-020210 RHEL-07-020220| Install SELinux related dependencies"
   yum:
       name:
-        - libselinux-python
-        - selinux-policy-targeted
-        - selinux-policy-mls
+          - libselinux-python
+          - selinux-policy-targeted
+          - selinux-policy-mls
   when:
       - rhel_07_020210 or rhel_07_020220
 

--- a/tests/docker/molecule/default/playbook-local.yml
+++ b/tests/docker/molecule/default/playbook-local.yml
@@ -5,14 +5,13 @@
   pre_tasks:
     - name: install packages for testing under docker
       yum:
-        name: "{{ item }}"
+        name:
+          - selinux-policy
+          - libselinux-python
+          - openssh-server
+          - which
+          - sudo
         state: present
-      with_items:
-        - selinux-policy
-        - libselinux-python
-        - openssh-server
-        - which
-        - sudo
 
     - name: Generate hostkey
       systemd:

--- a/tests/docker/molecule/default/playbook.yml
+++ b/tests/docker/molecule/default/playbook.yml
@@ -4,20 +4,18 @@
   pre_tasks:
     - name: install packages for testing under docker
       yum:
-        name: "{{ item }}"
+        name:
+          - selinux-policy
+          - libselinux-python
+          - openssh-server
+          - which
         state: present
-      with_items:
-        - selinux-policy
-        - libselinux-python
-        - openssh-server
-        - which
 
     - name: Generate hostkey
       systemd:
         name: sshd
         state: started
         enabled: true
-
 
   roles:
     - role: RHEL7-STIG


### PR DESCRIPTION
Description of PR
Fixes Deprecation warnings with the upgrade to Ansible 2.7.
Specifically it removes the loop that is no longer needed with the upgrade.

Type of change
Feature Pull Request

Fixes an issue

Fixes following Deprecation Warning

[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying name: {{ item }}, please use name: [u'snappy', u'snappy- devel', u'zlib', u'zlib-devel', u'hwloc', u'gcc', u'lzo', u'lzo-devel', u'python', u'make'] and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.