### PR TITLE
Some light updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -149,7 +149,7 @@ rhel_07_021620: true
 rhel_07_021700: true
 rhel_07_030010: true
 # if you set 030300 to 'true' ensure you define rhel7stig_audisp_remote_server
-rhel_07_030300: false
+rhel_07_030300: "{{ rhel7stig_audisp_remote_server is defined }}"
 rhel_07_030310: true
 rhel_07_030320: true
 rhel_07_030321: true
@@ -515,8 +515,8 @@ rhel7stig_login_defaults:
     umask: '077'
     create_home: 'yes'
 
-# RHEL-07-030300 set the value to a remote IP address that can receive audit logs
-#rhel7stig_audisp_remote_server: 10.10.10.10
+# RHEL-07-030300 uncomment and set the value to a remote IP address that can receive audit logs
+# rhel7stig_audisp_remote_server: 10.10.10.10
 
 # RHEL-07-030330: set this to 25% of the free space in /var/log/audit (measured in megabytes)
 rhel7stig_auditd_space_left: "{{ ( ansible_mounts | json_query(rhel7stig_audit_disk_size_query) | int / 4 / 1024 / 1024 ) | int + 1 }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,7 +148,8 @@ rhel_07_021300: true
 rhel_07_021620: true
 rhel_07_021700: true
 rhel_07_030010: true
-rhel_07_030300: true
+# if you set 030300 to 'true' ensure you define rhel7stig_audisp_remote_server
+rhel_07_030300: false
 rhel_07_030310: true
 rhel_07_030320: true
 rhel_07_030321: true
@@ -513,6 +514,9 @@ rhel7stig_login_defaults:
     fail_delay_secs: 4
     umask: '077'
     create_home: 'yes'
+
+# RHEL-07-030300 set the value to a remote IP address that can receive audit logs
+#rhel7stig_audisp_remote_server: 10.10.10.10
 
 # RHEL-07-030330: set this to 25% of the free space in /var/log/audit (measured in megabytes)
 rhel7stig_auditd_space_left: "{{ ( ansible_mounts | json_query(rhel7stig_audit_disk_size_query) | int / 4 / 1024 / 1024 ) | int + 1 }}"

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -12,6 +12,6 @@
       state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
       trivial_audit: "-w {{ item.path }} -p x {{ rhel7stig_workaround_for_ssg_benchmark | ternary('', '-F auid!=4294967295 ') }}-k {{ item.key }}"
-      normal_audit: "-a always,exit -F path={{ item.path }} -F perm=x -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
+      normal_audit: "-a always,exit -F path={{ item.path }} {% if not item.no_perm_x_filter is defined or not item.no_perm_x_filter %}-F perm=x{% endif %} -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
       audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -12,6 +12,6 @@
       state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
       trivial_audit: "-w {{ item.path }} -p x {{ rhel7stig_workaround_for_ssg_benchmark | ternary('', '-F auid!=4294967295 ') }}-k {{ item.key }}"
-      normal_audit: "-a always,exit -F path={{ item.path }} {% if not item.no_perm_x_filter is defined or not item.no_perm_x_filter %}-F perm=x{% endif %} -F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
+      normal_audit: "-a always,exit -F path={{ item.path }} {% if not item.no_perm_x_filter is defined or not item.no_perm_x_filter %}-F perm=x {% endif %}-F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
       audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -74,8 +74,8 @@
       regexp: 'nullok ?'
   when: rhel_07_010290
   with_items:
-    - /etc/pam.d/system-auth
-    - /etc/pam.d/password-auth
+      - /etc/pam.d/system-auth
+      - /etc/pam.d/password-auth
   tags:
       - RHEL-07-010290
 

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -69,10 +69,13 @@
 
 - name: "HIGH | RHEL-07-010290 | PATCH | The system must not have accounts configured with blank or null passwords."
   replace:
-      dest: /etc/pam.d/system-auth
+      dest: "{{ item }}"
       follow: true
       regexp: 'nullok ?'
   when: rhel_07_010290
+  with_items:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
   tags:
       - RHEL-07-010290
 

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1301,9 +1301,9 @@
 
 - name: "MEDIUM | RHEL-07-030300 | PATCH | The operating system must off-load audit records onto a different system or media from the system being audited."
   lineinfile:
-    path: /etc/audisp/audisp-remote.conf
-    regexp: ^remote_server +=
-    line: remote_server = {{ rhel7stig_audisp_remote_server }}
+      path: /etc/audisp/audisp-remote.conf
+      regexp: ^remote_server +=
+      line: remote_server = {{ rhel7stig_audisp_remote_server }}
   when: rhel_07_030300 and rhel7stig_audisp_remote_server
   tags:
       - RHEL-07-030300

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1565,9 +1565,7 @@
       - id: "030740"
         path: "/usr/bin/mount"
         key: "privileged-mount"
-      - id: "030740"
-        path: "/usr/bin/mount"
-        key: "privileged-mount"
+        no_perm_x_filter: true
       - id: "030750"
         path: "/usr/bin/umount"
         key: "privileged-mount"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1300,12 +1300,13 @@
       - RHEL-07-030010
 
 - name: "MEDIUM | RHEL-07-030300 | PATCH | The operating system must off-load audit records onto a different system or media from the system being audited."
-  command: "true"
-  changed_when: no
-  when: rhel_07_030300
+  lineinfile:
+    path: /etc/audisp/audisp-remote.conf
+    regexp: ^remote_server +=
+    line: remote_server = {{ rhel7stig_audisp_remote_server }}
+  when: rhel_07_030300 and rhel7stig_audisp_remote_server
   tags:
       - RHEL-07-030300
-      - notimplemented
 
 - name: "MEDIUM | RHEL-07-030310 | PATCH | The operating system must encrypt the transfer of audit records off-loaded onto a different system or media from the system being audited."
   lineinfile:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1302,7 +1302,7 @@
 - name: "MEDIUM | RHEL-07-030300 | PATCH | The operating system must off-load audit records onto a different system or media from the system being audited."
   lineinfile:
       path: /etc/audisp/audisp-remote.conf
-      regexp: ^remote_server +=
+      regexp: ^remote_server *=
       line: remote_server = {{ rhel7stig_audisp_remote_server }}
   when: rhel_07_030300 and rhel7stig_audisp_remote_server
   tags:


### PR DESCRIPTION
Summary

- Fixes 010290 which was failing SCAP checks due to password-auth not being remediate for the presence of nullok

- Add a capability to pass 030300

- Fixed a dup auditd for 030740 and made it so that rule would pass. It _was_ failing due to the presence of `perm-x` which is not part of the official guidance.