### PR TITLE
make tasks dynamic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,21 +19,21 @@
       - prelim_tasks
 
 - name: Include CAT I patches
-  import_tasks: fix-cat1.yml
+  include_tasks: fix-cat1.yml
   when: rhel7stig_cat1_patch | bool
   tags:
       - cat1
       - high
 
 - name: Include CAT II patches
-  import_tasks: fix-cat2.yml
+  include_tasks: fix-cat2.yml
   when: rhel7stig_cat2_patch | bool
   tags:
       - cat2
       - medium
 
 - name: Include CAT III patches
-  import_tasks: fix-cat3.yml
+  include_tasks: fix-cat3.yml
   when: rhel7stig_cat3_patch | bool
   tags:
       - cat3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   tags:
       - always
 
-- import_tasks: prelim.yml
+- include_tasks: prelim.yml
   become: yes
   tags:
       - prelim_tasks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   tags:
       - always
 
-- include_tasks: prelim.yml
+- import_tasks: prelim.yml
   become: yes
   tags:
       - prelim_tasks


### PR DESCRIPTION
I have a general hardening Playbook which has both RHEL6 and RHEL7 roles in the hierarchy which should be perfectly valid and reasonable. The use of 'import_tasks' forcibly adds the items and causes them to be evaluated individually only to be skipped by virtue of WHEN pre-conditions higher up. Changing to 'include_tasks' dramatically speeds up Ansible run time.