### PR TITLE
Fix up naming, block statements, and make 010260 use disruption-high mode for doc gen

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,8 +94,7 @@ rhel_07_010220: true
 rhel_07_010230: true
 rhel_07_010240: true
 rhel_07_010250: true
-# Potential for locking out users
-rhel_07_010260: false
+rhel_07_010260: true
 rhel_07_010270: true
 rhel_07_010280: true
 rhel_07_010310: true

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -432,7 +432,8 @@
       - RHEL-07-040540
       - shosts
 
-- block:
+- name: "HIGH | RHEL-07-040550 | PATCH | There must be no shosts.equiv files on the system."
+  block:
       - name: "HIGH | RHEL-07-040550 | AUDIT | There must be no shosts.equiv files on the system."
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -name 'shosts.equiv'
         check_mode: no

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -1,5 +1,5 @@
 ---
-- name: "HIGH | RHEL-07-010010 | PATCH | The file permissions, ownership, and group membership of system files and commands must match the vendor values."
+- name: "HIGH | RHEL-07-010010 | The file permissions, ownership, and group membership of system files and commands must match the vendor values."
   block:
       - name: "HIGH | RHEL-07-010010 | AUDIT | The file permissions, ownership, and group membership of system files and commands must match the vendor values."
         shell: |
@@ -42,7 +42,7 @@
   tags:
       - RHEL-07-010010
 
-- name: "HIGH | RHEL-07-010020 | PATCH | The cryptographic hash of system files and commands must match vendor values."
+- name: "HIGH | RHEL-07-010020 | The cryptographic hash of system files and commands must match vendor values."
   block:
       - name: "HIGH | RHEL-07-010020 | AUDIT | The cryptographic hash of system files and commands must match vendor values."
         shell: 'rpm -Va --nolinkto --nosize --nouser --nogroup --nomtime --nomode --nodigest --nosignature | grep ''^..5'' | grep -E ''/(.?bin|libexec)/'' | tee /dev/stderr | cut -c13- | sed ''s/^ //'' | xargs rpm -qf --qf=''%{name}\n'' | sort -u'
@@ -222,7 +222,7 @@
       - RHEL-07-020250
       - complexity-high
 
-- name: "HIGH | RHEL-07-020310 | PATCH | The root account must be the only account having unrestricted access to the system"
+- name: "HIGH | RHEL-07-020310 | The root account must be the only account having unrestricted access to the system"
   block:
       # Currently just locks user account
       - name: "HIGH | RHEL-07-020310 | AUDIT | The root account must be the only account having unrestricted access to the system"
@@ -240,7 +240,7 @@
   tags:
       - RHEL-07-020310
 
-- name: "HIGH | RHEL-07-021350 | PATCH | The operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards."
+- name: "HIGH | RHEL-07-021350 | The operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards."
   block:
       - name: "HIGH | RHEL-07-021350 | PATCH | The operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards."
         yum:
@@ -360,7 +360,7 @@
       - RHEL-07-021710
       - telnet
 
-- name: "HIGH | RHEL-07-030000 | PATCH | Auditing must be configured to produce records containing information to establish what type of events occurred, where the events occurred, the source of the events, and the outcome of the events. These audit records must also identify individual identities of group account users."
+- name: "HIGH | RHEL-07-030000 | Auditing must be configured to produce records containing information to establish what type of events occurred, where the events occurred, the source of the events, and the outcome of the events. These audit records must also identify individual identities of group account users."
   block:
       - name: "HIGH | RHEL-07-030000 | PATCH | Auditing must be configured to produce records containing information to establish what type of events occurred, where the events occurred, the source of the events, and the outcome of the events. These audit records must also identify individual identities of group account users."
         yum:
@@ -379,7 +379,7 @@
       - RHEL-07-030000
       - auditd
 
-- name: "HIGH | RHEL-07-032000 | PATCH | The system must use a DoD-approved virus scan program."
+- name: "HIGH | RHEL-07-032000 | The system must use a DoD-approved virus scan program."
   block:
       - name: "HIGH | RHEL-07-032000 | PATCH | The system must use a DoD-approved virus scan program."
         yum:
@@ -414,7 +414,7 @@
       - RHEL-07-040390
       - ssh
 
-- name: "HIGH | RHEL-07-040540 | PATCH | There must be no .shosts files on the system."
+- name: "HIGH | RHEL-07-040540 | There must be no .shosts files on the system."
   block:
       - name: "HIGH | RHEL-07-040540 | AUDIT | There must be no .shosts files on the system."
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -name '.shosts'
@@ -432,7 +432,7 @@
       - RHEL-07-040540
       - shosts
 
-- name: "HIGH | RHEL-07-040550 | PATCH | There must be no shosts.equiv files on the system."
+- name: "HIGH | RHEL-07-040550 | There must be no shosts.equiv files on the system."
   block:
       - name: "HIGH | RHEL-07-040550 | AUDIT | There must be no shosts.equiv files on the system."
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -name 'shosts.equiv'
@@ -489,7 +489,7 @@
       - RHEL-07-040710
       - ssh
 
-- name: "HIGH | RHEL-07-040800 | PATCH | SNMP community strings must be changed from the default."
+- name: "HIGH | RHEL-07-040800 | SNMP community strings must be changed from the default."
   block:
       - name: "HIGH | RHEL-07-040800 | AUDIT | SNMP community strings must be changed from the default."
         command: grep {{ item }} /etc/snmp/snmpd.conf

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -414,7 +414,8 @@
       - RHEL-07-040390
       - ssh
 
-- block:
+- name: "HIGH | RHEL-07-040540 | PATCH | There must be no .shosts files on the system."
+  block:
       - name: "HIGH | RHEL-07-040540 | AUDIT | There must be no .shosts files on the system."
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -name '.shosts'
         check_mode: no

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -222,7 +222,8 @@
       - RHEL-07-020250
       - complexity-high
 
-- block:
+- name: "HIGH | RHEL-07-020310 | PATCH | The root account must be the only account having unrestricted access to the system"
+  block:
       # Currently just locks user account
       - name: "HIGH | RHEL-07-020310 | AUDIT | The root account must be the only account having unrestricted access to the system"
         shell: "cat /etc/passwd | awk -F: '($3 == 0 && $1 != \"root\") {i++;print $1 } END {exit i}'"

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -489,8 +489,9 @@
       - RHEL-07-040710
       - ssh
 
-- block:
-      - name: "PRELIM | RHEL-07-040800 | AUDIT | SNMP community strings must be changed from the default."
+- name: "HIGH | RHEL-07-040800 | PATCH | SNMP community strings must be changed from the default."
+  block:
+      - name: "HIGH | RHEL-07-040800 | AUDIT | SNMP community strings must be changed from the default."
         command: grep {{ item }} /etc/snmp/snmpd.conf
         check_mode: no
         failed_when: no

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -42,7 +42,8 @@
   tags:
       - RHEL-07-010010
 
-- block:
+- name: "HIGH | RHEL-07-010020 | PATCH | The cryptographic hash of system files and commands must match vendor values."
+  block:
       - name: "HIGH | RHEL-07-010020 | AUDIT | The cryptographic hash of system files and commands must match vendor values."
         shell: 'rpm -Va --nolinkto --nosize --nouser --nogroup --nomtime --nomode --nodigest --nosignature | grep ''^..5'' | grep -E ''/(.?bin|libexec)/'' | tee /dev/stderr | cut -c13- | sed ''s/^ //'' | xargs rpm -qf --qf=''%{name}\n'' | sort -u'
         args:

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -360,7 +360,8 @@
       - RHEL-07-021710
       - telnet
 
-- block:
+- name: "HIGH | RHEL-07-030000 | PATCH | Auditing must be configured to produce records containing information to establish what type of events occurred, where the events occurred, the source of the events, and the outcome of the events. These audit records must also identify individual identities of group account users."
+  block:
       - name: "HIGH | RHEL-07-030000 | PATCH | Auditing must be configured to produce records containing information to establish what type of events occurred, where the events occurred, the source of the events, and the outcome of the events. These audit records must also identify individual identities of group account users."
         yum:
             name: audit

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -379,7 +379,8 @@
       - RHEL-07-030000
       - auditd
 
-- block:
+- name: "HIGH | RHEL-07-032000 | PATCH | The system must use a DoD-approved virus scan program."
+  block:
       - name: "HIGH | RHEL-07-032000 | PATCH | The system must use a DoD-approved virus scan program."
         yum:
             name: "{{ rhel7stig_av_package.package }}"

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -240,7 +240,8 @@
   tags:
       - RHEL-07-020310
 
-- block:
+- name: "HIGH | RHEL-07-021350 | PATCH | The operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards."
+  block:
       - name: "HIGH | RHEL-07-021350 | PATCH | The operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards."
         yum:
             name: dracut-fips

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -124,7 +124,6 @@
 
 
 - name: |
-
       "HIGH | RHEL-07-010480 | PATCH | Systems with a Basic Input/Output System (BIOS) must require authentication upon booting into single-user and maintenance modes."
       "HIGH | RHEL-07-010490 | PATCH | Systems using Unified Extensible Firmware Interface (UEFI) must require authentication upon booting into single-user and maintenance modes."
   lineinfile:

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -1,5 +1,6 @@
 ---
-- block:
+- name: "HIGH | RHEL-07-010010 | PATCH | The file permissions, ownership, and group membership of system files and commands must match the vendor values."
+  block:
       - name: "HIGH | RHEL-07-010010 | AUDIT | The file permissions, ownership, and group membership of system files and commands must match the vendor values."
         shell: |
             rpm -Va --nolinkto --nofiledigest --nosize --nomtime --nodigest --nosignature | grep -E '^(.M|.....U|......G)' | tee /dev/stderr | cut -c13- | sed 's/^ //' | xargs rpm -qf --qf='%{name}\n' | sort -u

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2264,7 +2264,8 @@
   tags:
       - RHEL-07-040670
 
-- block:
+- name: "MEDIUM | RHEL-07-040680 | PATCH | The system must be configured to prevent unrestricted mail relaying."
+  block:
       - name: "MEDIUM | RHEL-07-040680 | AUDIT | Check if postfix is installed."
         command: rpm -q postfix
         failed_when: no

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2063,7 +2063,8 @@
       - RHEL-07-040470
       - ssh
 
-- block:
+- name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
+  block:
       - name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
         yum:
             name: chrony
@@ -2090,7 +2091,8 @@
       - ntp
       - ntpd
 
-- block:
+- name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
+  block:
       - name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
         yum:
             name: ntp

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -317,14 +317,19 @@
 
       - name: "MEDIUM | RHEL-07-010260 | PATCH | Reset password timeout to prevent locking out user."
         command: chage -d '-1 day' {{ item }}
+        check_mode: "{{ rhel7stig_disruptive_check_mode }}"
         with_items: "{{ rhel_07_010260_audit.stdout_lines }}"
 
       - name: "MEDIUM | RHEL-07-010260 | PATCH | Existing passwords must be restricted to a 60-day maximum lifetime."
         command: chage -M 60 {{ item }}
+        check_mode: "{{ rhel7stig_disruptive_check_mode }}"
         with_items: "{{ rhel_07_010260_audit.stdout_lines }}"
-  when: rhel_07_010260
+  when:
+      - rhel_07_010260
+      - rhel7stig_disruptive
   tags:
       - RHEL-07-010260
+      - disruption-high
       - password
 
 - name: "MEDIUM | RHEL-07-010270 | PATCH | The Red Hat Enterprise Linux operating system must be configured so that passwords are prohibited from reuse for a minimum of five generations."

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1242,7 +1242,8 @@
       - RHEL-07-021120
       - cron
 
-- block:
+- name: "MEDIUM | RHEL-07-021300 | PATCH | Kernel core dumps must be disabled unless needed."
+  block:
       - name: "MEDIUM | RHEL-07-021300 | PATCH | Kernel core dumps must be disabled unless needed."
         shell: "systemctl show kdump | grep LoadState | cut -d = -f 2"
         register: rhel_07_021300_kdump_service_status

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2244,7 +2244,8 @@
       - RHEL-07-040660
       - ipv4
 
-- block:
+- name: "MEDIUM | RHEL-07-040670 | PATCH | Network interfaces must not be in promiscuous mode."
+  block:
       - name: "MEDIUM | RHEL-07-040670 | PATCH | Network interfaces must not be in promiscuous mode."
         shell: "ip link | grep -i promisc | cut -d ':' -f 2"
         check_mode: no

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -394,7 +394,10 @@
   tags:
       - RHEL-07-010310
 
-- block:
+- name: |
+        "MEDIUM | RHEL-07-010320 | PATCH | Accounts on the Red Hat Enterprise Linux operating system that are subject to three unsuccessful logon attempts within 15 minutes must be locked for the maximum configurable period."
+        "MEDIUM | RHEL-07-010330 | PATCH | The Red Hat Enterprise Linux operating system must lock the associated account after three unsuccessful root logon attempts are made within a 15-minute period."
+  block:
       - name: |
               "MEDIUM | RHEL-07-010320 | PATCH | Accounts on the Red Hat Enterprise Linux operating system that are subject to three unsuccessful logon attempts within 15 minutes must be locked for the maximum configurable period."
               "MEDIUM | RHEL-07-010330 | PATCH | The Red Hat Enterprise Linux operating system must lock the associated account after three unsuccessful root logon attempts are made within a 15-minute period."

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2370,7 +2370,8 @@
       - RHEL-07-040830
       - ipv6
 
-- block:
+- name: "MEDIUM | RHEL-07-041001 | PATCH | The operating system must have the required packages for multifactor authentication installed."
+  block:
       - name: "MEDIUM | RHEL-07-041001 | PATCH | The operating system must have the required packages for multifactor authentication installed."
         yum:
             name:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -332,7 +332,7 @@
       - disruption-high
       - password
 
-- name: "MEDIUM | RHEL-07-010270 | PATCH | The Red Hat Enterprise Linux operating system must be configured so that passwords are prohibited from reuse for a minimum of five generations."
+- name: "MEDIUM | RHEL-07-010270 | The Red Hat Enterprise Linux operating system must be configured so that passwords are prohibited from reuse for a minimum of five generations."
   block:
       - name: "MEDIUM | RHEL-07-010270 | PATCH | Ensure pam_pwhistory rule exists"
         pamd:
@@ -400,8 +400,8 @@
       - RHEL-07-010310
 
 - name: |
-        "MEDIUM | RHEL-07-010320 | PATCH | Accounts on the Red Hat Enterprise Linux operating system that are subject to three unsuccessful logon attempts within 15 minutes must be locked for the maximum configurable period."
-        "MEDIUM | RHEL-07-010330 | PATCH | The Red Hat Enterprise Linux operating system must lock the associated account after three unsuccessful root logon attempts are made within a 15-minute period."
+        "MEDIUM | RHEL-07-010320 | Accounts on the Red Hat Enterprise Linux operating system that are subject to three unsuccessful logon attempts within 15 minutes must be locked for the maximum configurable period."
+        "MEDIUM | RHEL-07-010330 | The Red Hat Enterprise Linux operating system must lock the associated account after three unsuccessful root logon attempts are made within a 15-minute period."
   block:
       - name: |
               "MEDIUM | RHEL-07-010320 | PATCH | Accounts on the Red Hat Enterprise Linux operating system that are subject to three unsuccessful logon attempts within 15 minutes must be locked for the maximum configurable period."
@@ -572,7 +572,7 @@
 # User can override some settings of the rescue.service unit by placing the overridden lines in /etc/systemd/system/rescue.service.d/override.conf
 # Additionally the user can provide the -e or --force options to /usr/sbin/sulogin which will provide a root shell without password if the
 # password file is inaccessbile or the root password is non-existent, LOCKED, or damaged.
-- name: "MEDIUM | RHEL-07-010481 | PATCH | The operating system must require authentication upon booting into single-user and maintenance modes."
+- name: "MEDIUM | RHEL-07-010481 | The operating system must require authentication upon booting into single-user and maintenance modes."
   block:
       - name: "MEDIUM | RHEL-07-010481 | PATCH | Check if the packaged rescue.service file was edited directly"
         shell: "cat /usr/lib/systemd/system/rescue.service | grep 'ExecStart=.*/usr/sbin/sulogin'"
@@ -700,7 +700,7 @@
       - login
       - umask
 
-- name: "MEDIUM | RHEL-07-020260 | PATCH | Vendor packaged system security patches and updates must be installed and up to date."
+- name: "MEDIUM | RHEL-07-020260 | Vendor packaged system security patches and updates must be installed and up to date."
   block:
       - name: "MEDIUM | RHEL-07-020260 | AUDIT | Check RHEL type"
         command: rpm -q redhat-release-workstation
@@ -1093,7 +1093,7 @@
       - RHEL-07-020730
       - notimplemented
 
-- name: "MEDIUM | RHEL-07-020900 | AUDIT | All system device files must be correctly labeled to prevent unauthorized modification."
+- name: "MEDIUM | RHEL-07-020900 | All system device files must be correctly labeled to prevent unauthorized modification."
   block:
       - name: "MEDIUM | RHEL-07-020900 | AUDIT | All system device files must be correctly labeled to prevent unauthorized modification."
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev ( -context *:device_t:* -o -context *:unlabeled_t:* ) ( -type c -o -type b ) -printf '%p %Z\n'
@@ -1177,7 +1177,7 @@
   tags:
       - RHEL-07-021021
 
-- name: "MEDIUM | RHEL-07-021030 | PATCH | All world-writable directories must be group-owned by root, sys, bin, or an application group."
+- name: "MEDIUM | RHEL-07-021030 | All world-writable directories must be group-owned by root, sys, bin, or an application group."
   block:
       - name: "MEDIUM | RHEL-07-021030 | AUDIT | All world-writable directories must be group-owned by root, sys, bin, or an application group."
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -type d -perm -002 -gid +999
@@ -1223,8 +1223,8 @@
       - RHEL-07-021100
 
 - name: |
-        MEDIUM | RHEL-07-021110 | PATCH | If the cron.allow file exists it must be owned by root.
-        MEDIUM | RHEL-07-021120 | PATCH | If the cron.allow file exists it must be group-owned by root.
+        MEDIUM | RHEL-07-021110 | If the cron.allow file exists it must be owned by root.
+        MEDIUM | RHEL-07-021120 | If the cron.allow file exists it must be group-owned by root.
   block:
       - name: "MEDIUM | RHEL-07-021110, RHEL-07-021120 | PATCH | Check if cron.allow file exists"
         stat:
@@ -1247,7 +1247,7 @@
       - RHEL-07-021120
       - cron
 
-- name: "MEDIUM | RHEL-07-021300 | PATCH | Kernel core dumps must be disabled unless needed."
+- name: "MEDIUM | RHEL-07-021300 | Kernel core dumps must be disabled unless needed."
   block:
       - name: "MEDIUM | RHEL-07-021300 | PATCH | Kernel core dumps must be disabled unless needed."
         shell: "systemctl show kdump | grep LoadState | cut -d = -f 2"
@@ -1267,7 +1267,7 @@
   tags:
       - RHEL-07-021300
 
-- name: "MEDIUM | RHEL-07-021620 | PATCH | The file integrity tool must use FIPS 140-2 approved cryptographic hashes for validating file contents and directories."
+- name: "MEDIUM | RHEL-07-021620 | The file integrity tool must use FIPS 140-2 approved cryptographic hashes for validating file contents and directories."
   block:
       - name: "Replace sha256+sha512 entries with sha512"
         replace:
@@ -1380,7 +1380,7 @@
   tags:
       - RHEL-07-030350
 
-- name: "MEDIUM | RHEL-07-030360 | PATCH | All privileged function executions must be audited."
+- name: "MEDIUM | RHEL-07-030360 | All privileged function executions must be audited."
   block:
       - name: "MEDIUM | RHEL-07-030360 | AUDIT | All privileged function executions must be audited. (find suid/sgid programs)"
         command: find {{ rhel7stig_local_mounts | join(' ') }} -xdev -type f ( -perm -4000 -o -perm -2000 )
@@ -2068,7 +2068,7 @@
       - RHEL-07-040470
       - ssh
 
-- name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
+- name: "MEDIUM | RHEL-07-040500 | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
   block:
       - name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
         yum:
@@ -2096,7 +2096,7 @@
       - ntp
       - ntpd
 
-- name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
+- name: "MEDIUM | RHEL-07-040500 | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
   block:
       - name: "MEDIUM | RHEL-07-040500 | PATCH | The operating system must, for networked systems, synchronize clocks with a server that is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS)."
         yum:
@@ -2249,7 +2249,7 @@
       - RHEL-07-040660
       - ipv4
 
-- name: "MEDIUM | RHEL-07-040670 | PATCH | Network interfaces must not be in promiscuous mode."
+- name: "MEDIUM | RHEL-07-040670 | Network interfaces must not be in promiscuous mode."
   block:
       - name: "MEDIUM | RHEL-07-040670 | PATCH | Network interfaces must not be in promiscuous mode."
         shell: "ip link | grep -i promisc | cut -d ':' -f 2"
@@ -2269,7 +2269,7 @@
   tags:
       - RHEL-07-040670
 
-- name: "MEDIUM | RHEL-07-040680 | PATCH | The system must be configured to prevent unrestricted mail relaying."
+- name: "MEDIUM | RHEL-07-040680 | The system must be configured to prevent unrestricted mail relaying."
   block:
       - name: "MEDIUM | RHEL-07-040680 | AUDIT | Check if postfix is installed."
         command: rpm -q postfix
@@ -2375,7 +2375,7 @@
       - RHEL-07-040830
       - ipv6
 
-- name: "MEDIUM | RHEL-07-041001 | PATCH | The operating system must have the required packages for multifactor authentication installed."
+- name: "MEDIUM | RHEL-07-041001 | The operating system must have the required packages for multifactor authentication installed."
   block:
       - name: "MEDIUM | RHEL-07-041001 | PATCH | The operating system must have the required packages for multifactor authentication installed."
         yum:

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -9,7 +9,7 @@
   tags:
       - RHEL-07-020200
 
-- name: "LOW | RHEL-07-020300 | PATCH | All Group Identifiers (GIDs) referenced in the /etc/passwd file must be defined in the /etc/group file."
+- name: "LOW | RHEL-07-020300 | All Group Identifiers (GIDs) referenced in the /etc/passwd file must be defined in the /etc/group file."
   block:
       - name: "LOW | RHEL-07-020300 | PATCH | Check /etc/passwd entries"
         shell: pwck -r | grep 'no group' | awk '{ gsub("[:\47]",""); print $2}'


### PR DESCRIPTION
These fixes/changes are mainly to support the documentation generation that is in the `migrate_ah_docs` branch 725b2bf.

The changes split by atomic commits so it is easy to review. There are name updates to bring them in line with the standard, addition of a name parameter so there are no bare `block` statements, and the last change makes the RHEL-07-010260 task be a disruption-high item instead of just being disabled by default since the reasoning for disabling it was that it has a high chance of locking out users.

Once this is merged I can work on getting the doc generation merged in and running for the devel branch.