### PR TITLE
update travis to pull from new RH registry loc with auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
     if [ "${TYPE}" == "docker" ]; then
       docker pull centos/systemd
       if [[ "${TRAVIS_PULL_REQUEST}" == "false" || "${TRAVIS_PULL_REQUEST_SLUG}" == "MindPointGroup/RHEL7-STIG" ]]; then
-        docker pull registry.access.redhat.com/rhel7:latest
+        docker login -u=$RHR_USER -p=$RHR_TOKEN registry.redhat.io
+        docker pull registry.redhat.io/rhel7:latest
         (cd molecule/docker; docker build --build-arg rhn_user=$RHN_USERNAME --build-arg rhn_pass=$RHN_PASSWORD -t  molly .)
       else
         sed -i '/- name: RHEL/,/- docker/d' ./molecule/docker/molecule.yml

--- a/molecule/docker/Dockerfile
+++ b/molecule/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7:latest
+FROM registry.redhat.io/rhel7:latest
 
 # Build Arguments
 ARG rhn_user


### PR DESCRIPTION
Red Hat is migrating their container registry from `registry.access.redhat.com` to `registry.redhat.io` and going forward will require auth even for pull operations. This updates the Travis config to account for that.