### PR TITLE
V2R1 Rule change for RHEL-07-010119

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -130,7 +130,7 @@
 - name: "MEDIUM | RHEL-07-010119 | PATCH | When passwords are changed or new passwords are established, pwquality must be used"
   lineinfile:
       create: yes
-      dest: /etc/pam.d/passwd
+      dest: /etc/pam.d/system-auth
       regexp: '^#?password required pam_pwquality.so retry'
       line: password required pam_pwquality.so retry=3
   when: rhel_07_010119


### PR DESCRIPTION
change /etc/pam.d/passwd to /etc/pam.d/system-auth

Description
Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.
Solution
Configure the operating system to use "pwquality" to enforce password complexity rules.

Add the following line to "/etc/pam.d/system-auth" (or modify the line to have the required value):

password required pam_pwquality.so retry=3

Note: The value of "retry" should be between "1" and "3".
