### PR TITLE
Don't enable yum-cron by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -457,8 +457,9 @@ rhel7stig_ssh_session_timeout: 600
 # minimal                            = yum --bugfix upgrade-minimal
 # minimal-security                   = yum --security upgrade-minimal
 # minimal-security-severity:Critical =  --sec-severity=Critical upgrade-minimal
+rhel7stig_auto_package_updates_enabled: no
 rhel7stig_auto_package_updates:
-    enabled: yes
+    enabled: "{{ rhel7stig_auto_package_updates_enabled }}"
     update_cmd: "minimal-security"
     frequency: daily
 

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -718,6 +718,10 @@
   args:
       warn: no
   register: rhel_07_020260_yum_cron_installed
+  when: rhel_07_020260
+  tags:
+      - RHEL-07-020260
+      - packaging
 
 - name: "MEDIUM | RHEL-07-020260 | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date."
   block:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -716,16 +716,23 @@
               yum:
                   name: yum-cron
                   state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary('present','absent')}}"
-                  enablerepo: "{{ (ansible_distribution == 'RedHat') | ternary('rhel-7-' +
-                          (rhel_07_020260_rhel_type.rc == 0) | ternary('workstation', 'server') +
-                          '-optional-rpms', omit) }}"
         rescue:
-            # Might be an AWS RHEL instance, try it...
             - name: "MEDIUM | RHEL-07-020260 | PATCH | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date. | Install yum-cron"
-              yum:
-                  name: yum-cron
-                  state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary('present','absent')}}"
-                  enablerepo: rhui-REGION-rhel-server-optional
+              block:
+                  - name: "MEDIUM | RHEL-07-020260 | PATCH | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date. | Install yum-cron"
+                    yum:
+                        name: yum-cron
+                        state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary('present','absent')}}"
+                        enablerepo: "{{ 'rhel-7-' ~ (rhel_07_020260_rhel_type.rc == 0) |
+                                ternary('workstation', 'server') ~ '-optional-rpms' }}"
+
+              rescue:
+                  # Might be an AWS RHEL instance, try it...
+                  - name: "MEDIUM | RHEL-07-020260 | PATCH | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date. | Install yum-cron"
+                    yum:
+                        name: yum-cron
+                        state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary('present','absent')}}"
+                        enablerepo: rhui-REGION-rhel-server-optional
 
       - name: "MEDIUM | RHEL-07-020260 | PATCH | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date. | Verify yum-cron config file exists"
         stat:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -700,6 +700,25 @@
       - login
       - umask
 
+
+- name: "MEDIUM | RHEL-07-020260 | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date."
+  yum:
+      name: '*'
+      state: latest
+  when: rhel_07_020260
+  tags:
+      - RHEL-07-020260
+      - packaging
+
+- name: "MEDIUM | RHEL-07-020260 | AUDIT | Check if yum-cron is installed"
+  command: rpm -q yum-cron
+  check_mode: no
+  changed_when: no
+  failed_when: no
+  args:
+      warn: no
+  register: rhel_07_020260_yum_cron_installed
+
 - name: "MEDIUM | RHEL-07-020260 | The Red Hat Enterprise Linux operating system security patches and updates must be installed and up to date."
   block:
       - name: "MEDIUM | RHEL-07-020260 | AUDIT | Check RHEL type"
@@ -769,7 +788,10 @@
             state: "{{ (rhel7stig_auto_package_updates.enabled) | ternary(rhel7stig_service_started, 'stopped')}}"
         when: rhel_07_020260_yumcron_service_status.stdout == "loaded"
 
-  when: rhel_07_020260
+  when:
+      - rhel_07_020260
+      - rhel7stig_auto_package_updates_enabled or
+        rhel_07_020260_yum_cron_installed.rc == 0
   tags:
       - RHEL-07-020260
       - packaging


### PR DESCRIPTION
also avoid munging repos.  Failure occur if the optional-rpms repo is not available even if it's not needed, when it's explicitly requested.

fixes #204