### PR TITLE
temp sshd keys for config validation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -50,6 +50,14 @@
   command: auditctl -f {{ rhel7stig_auditd_failure_flag }}
   failed_when: no
 
+- name: clean up ssh host key
+  file:
+      path: "{{ item }}"
+      state: absent
+  with_items:
+      - /etc/ssh/ssh_host_rsa_key
+      - /etc/ssh/ssh_host_rsa_key.pub
+
 - name: init aide and wait
   command: /usr/sbin/aide --init -B 'database_out=file:{{ rhel7stig_aide_temp_db_file }}'
   notify: move aide db

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -213,6 +213,12 @@
         yum:
             name: openssh-server
 
+      - name: PRELIM | Start SSH
+        service:
+            name: sshd
+            state: "{{ rhel7stig_service_started }}"
+            enabled: yes
+
       - name: PRELIM | check if ssh host key exists
         stat:
             path: /etc/ssh/ssh_host_rsa_key

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -207,7 +207,19 @@
   when:
       - rhel_07_020210 or rhel_07_020220
 
-- name: "PRELIM | Install SSH"
-  yum:
-      name: openssh-server
+- name: "PRELIM | Bare bones SSH Server"
+  block:
+      - name: "PRELIM | Install SSH"
+        yum:
+            name: openssh-server
+
+      - name: PRELIM | check if ssh host key exists
+        stat:
+            path: /etc/ssh/ssh_host_rsa_key
+        register: rhel7stig_ssh_host_rsa_key_stat
+
+      - name: PRELIM | create ssh host key to allow 'sshd -t -f %s' to succeed
+        command: ssh-keygen -N '' -f /etc/ssh/ssh_host_rsa_key -t rsa -b 4096
+        when: not rhel7stig_ssh_host_rsa_key_stat.stat.exists
+        notify: clean up ssh host key
   when: rhel7stig_ssh_required


### PR DESCRIPTION
if the keys don't exist, "sshd -t -f %s" fails

remove the keys at the end to allow the normal key generation process to take place