### PR TITLE
STIG requires targeted policy, not mls

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -203,7 +203,6 @@
       name:
           - libselinux-python
           - selinux-policy-targeted
-          - selinux-policy-mls
   when:
       - rhel_07_020210 or rhel_07_020220
 


### PR DESCRIPTION
avoid unnecessary packages