### PR TITLE
pam_lastlog: "silent" most not be present

### DIFF
--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -143,6 +143,15 @@
 
 - name: "LOW | RHEL-07-040530 | The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon logon."
   block:
+      - name: "LOW | RHEL-07-040530 | Update pam_lastlog control to satisfy benchmark."
+        pamd:
+            name: postlogin
+            type: session
+            control: "{{ old_control }}"
+            new_control: "{{ default_control }}"
+            module_path: pam_lastlog.so
+            state: updated
+
       - name: "LOW | RHEL-07-040530 | The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon logon."
         pamd:
             name: postlogin
@@ -153,7 +162,7 @@
             module_arguments: silent
         with_items:
             - '[default=1]'
-            - optional
+            - "{{ default_control }}"
 
       - name: "MEDIUM | RHEL-07-010270 | PATCH | Remove old remediation"
         blockinfile:
@@ -163,6 +172,9 @@
             block: |
                 ### RHEL-07-040530 ###
                 session required pam_lastlog.so showfailed
+  vars:
+      default_control: "{{ rhel7stig_workaround_for_disa_benchmark | ternary('required', 'optional') }}"
+      old_control: "{{ rhel7stig_workaround_for_disa_benchmark | ternary('optional', 'required') }}"
   when: rhel_07_040530
   tags:
       - RHEL-07-040530

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -141,14 +141,28 @@
   tags:
       - RHEL-07-040000
 
-- name: "LOW | RHEL-07-040530 | PATCH | The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon logon."
-  blockinfile:
-      state: present
-      path: /etc/pam.d/postlogin
-      insertafter: '^# User changes will be destroyed'
-      block: |
-          ### RHEL-07-040530 ###
-          session required pam_lastlog.so showfailed
+- name: "LOW | RHEL-07-040530 | The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon logon."
+  block:
+      - name: "LOW | RHEL-07-040530 | The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon logon."
+        pamd:
+            name: postlogin
+            state: args_absent
+            type: session
+            control: "{{ item }}"
+            module_path: pam_lastlog.so
+            module_arguments: silent
+        with_items:
+            - '[default=1]'
+            - optional
+
+      - name: "MEDIUM | RHEL-07-010270 | PATCH | Remove old remediation"
+        blockinfile:
+            state: absent
+            path: /etc/pam.d/postlogin
+            insertafter: '^# User changes will be destroyed'
+            block: |
+                ### RHEL-07-040530 ###
+                session required pam_lastlog.so showfailed
   when: rhel_07_040530
   tags:
       - RHEL-07-040530


### PR DESCRIPTION
If "pam_lastlog" is missing from "/etc/pam.d/postlogin" file, or the
silent option is present, this is a finding.

A compliant line is already placed by the role, but the DISA benchmark
is flagging another default line as non-compliant.

I'd appreciate any testing against existing setups; things worked fine for me w/ this change.