### PR TITLE
remove banner line breaks to satisfy benchmark

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -395,7 +395,10 @@ rhel7stig_aide_conf:
 # Set maximum number of simultaneous system logins (RHEL-07-040000)
 rhel7stig_maxlogins: 10
 
-rhel7stig_logon_banner: |
+rhel7stig_logon_banner: "{{ rhel7stig_workaround_for_disa_benchmark | ternary(
+        rhel7stig_logon_banner_nice | regex_replace('(?s)(?<!\\n)\\n(?!(\n|$))', ' '),
+        rhel7stig_logon_banner_nice) }}"
+rhel7stig_logon_banner_nice: |
     You are accessing a U.S. Government (USG) Information System (IS) that is
     provided for USG-authorized use only.
 


### PR DESCRIPTION
this makes the banner somewhat hard to read

The V2R2 benchmark badly tries to make sure that there is no extra text in the banner, and the "extra" line breaks cause a false positive rule failure.  This works around that by removing our extra line breaks.