### PR TITLE
sync BIOS and UEFI grub config paths

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -560,7 +560,8 @@ rhel7stig_audit_part: "{{ rhel_07_audit_part.stdout }}"
 rhel7stig_boot_part: "{{ rhel_07_boot_part.stdout }}"
 
 rhel7stig_machine_uses_uefi: "{{ rhel_07_sys_firmware_efi.stat.exists }}"
-rhel7stig_grub_cfg_path: "{{ rhel7stig_machine_uses_uefi | ternary('/boot/efi/EFI/{{ ansible_distribution | lower }}/grub.cfg', '/boot/grub2/grub.cfg') }}"
+rhel7stig_grub_cfg_path: "{{ rhel7stig_machine_uses_uefi | ternary('/boot/efi/EFI/' ~ (ansible_distribution | lower) ~ '/grub.cfg', '/boot/grub2/grub.cfg') }}"
+rhel7stig_grub_cfg_path_invalid: "{{ (not rhel7stig_machine_uses_uefi) | ternary('/boot/efi/EFI/' ~ (ansible_distribution | lower) ~ '/grub.cfg', '/boot/grub2/grub.cfg') }}"
 
 rhel7stig_passwd_label: "{{ (this_item | default(item)).id }}: {{ (this_item | default(item)).dir }}"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -33,7 +33,10 @@
   with_items:
       - grub.cfg
       - user.cfg
-  when: rhel7stig_workaround_for_disa_benchmark
+  when:
+      - rhel7stig_workaround_for_disa_benchmark
+      - not rhel7stig_skip_for_travis
+      - not rhel7stig_system_is_container
 
 - name: "restart {{ rhel7stig_time_service }}"
   service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -24,6 +24,17 @@
       - not rhel7stig_skip_for_travis
       - not rhel7stig_system_is_container
 
+- name: copy grub2 config to BIOS/UEFI to satisfy benchmark
+  listen: make grub2 config
+  copy:
+      src: "{{ rhel7stig_grub_cfg_path | dirname }}/{{ item }}"
+      dest: "{{ rhel7stig_grub_cfg_path_invalid | dirname }}/{{ item }}"
+      remote_src: yes
+  with_items:
+      - grub.cfg
+      - user.cfg
+  when: rhel7stig_workaround_for_disa_benchmark
+
 - name: "restart {{ rhel7stig_time_service }}"
   service:
       name: "{{ rhel7stig_time_service }}"


### PR DESCRIPTION
The DISA benchmark V2R2 fails 3 rules (1 high, 2 medium) if both UEFI
and BIOS paths are not present.

Even so, this only fixes things for RHEL 7.5 or earlier.  The DISA benchmark does not recognize 7.6 as a supported release, causing a failure of these 3 rules, plus the "supported OS" rule.  You can workaround that one by setting '7.6' to '7.5' in /etc/redhat-release, but I'm not going to automate that here -- besides, it would be overwritten by the 'file checksum must match RPM value'