### PR TITLE
audit: kmod still requires "-f perm=x" in V2R2

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1684,7 +1684,6 @@
         path: "/usr/bin/kmod"
         trivial: yes
         key: "module-change"
-        no_perm_x_filter: true
   tags:
       - audit-rules
 


### PR DESCRIPTION
https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72191?version=V1R4&compareto=V2R2

resolves comment on #174