### PR TITLE
enable aide mail in disruption-high mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,7 +112,7 @@ rhel_07_010500: true
 rhel_07_020020: true
 rhel_07_020030: true
 # Send AIDE reports as mail notifications - Disabled by default as this is a non-ideal way to do notifications
-rhel_07_020040: false
+rhel_07_020040: "{{ rhel7stig_disruption_high }}"
 rhel_07_020100: true
 rhel_07_020101: true
 rhel_07_020110: true


### PR DESCRIPTION
This helps makes a system as compliant as possible when using `rhel7stig_disruption_high: yes`