### PR TITLE
fix local.yml for ansible-2.4

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -3,7 +3,6 @@
   connection: local
   become: yes
   vars:
-      ansible_python_interpreter: "{{ ansible_playbook_python }}"
       is_container: false
   roles:
       - role: "{{ playbook_dir }}"


### PR DESCRIPTION
ansible_python_interpreter is already set automatically by ansible
exactly as this line attempts to do