### PR TITLE
adds imrelp to rhel-07-031010 & space following #

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1757,10 +1757,11 @@
   replace:
       path: /etc/rsyslog.conf
       regexp: '({{ item }})'
-      replace: '#\1'
+      replace: '# \1'
   with_items:
       - '^(\$ModLoad imtcp)'
       - '^(\$ModLoad imudp)'
+      - '^(\$ModLoad imrelp)'
       - '^(\$UDPServerRun)'
       - '^(\$InputTCPServerRun)'
   when:


### PR DESCRIPTION
RHEL-07-031010 references a requirement to prevent `imrelp` in `/etc/rsyslog.conf` that is not currently present.  I also added space following the `#` for readability purposes.