### PR TITLE
quote packages names

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -19,7 +19,7 @@
 
       - name: "HIGH | RHEL-07-010010 | PATCH | The Red Hat Enterprise Linux operating system must be configured so that the file permissions, ownership, and group membership of system files and commands match the vendor values."
         shell: >
-                ( rpm --setugids {{ item }}; rpm --setperms {{ item }} )
+                ( rpm --setugids {{ item | quote }}; rpm --setperms {{ item | quote }} )
                 2>&1 1>&2 | grep -v ': No such file or directory$'
         args:
             warn: no


### PR DESCRIPTION
previously this task failed if a failing package name had whitespace