### PR TITLE
remove only tftp-server

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -505,7 +505,6 @@
 - name: "HIGH | RHEL-07-040700 | PATCH | The Red Hat Enterprise Linux operating system must not have the Trivial File Transfer Protocol (TFTP) server package installed if not required for operational support."
   yum:
       name:
-          - tftp
           - tftp-server
       state: absent
   when:


### PR DESCRIPTION
as of V2R1, the check content and fix content match in requiring the
absence of the tftp-server, not the tftp package -- previously, the fix
content said to get rid of the tftp package

related #174