### PR TITLE
disable usb-storage /bin/true

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -647,7 +647,7 @@
       - regexp: "^(#)?blacklist usb-storage(\\s|$)"
         line: 'blacklist usb-storage'
       - regexp: "^(#)?install usb-storage"
-        line: 'install usb-storage /bin/false'
+        line: install usb-storage /bin/true
   when: rhel_07_020100
   tags:
       - RHEL-07-020100

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -637,6 +637,7 @@
 - name: "MEDIUM | RHEL-07-020100 | PATCH | The Red Hat Enterprise Linux operating system must be configured to disable USB mass storage."
   lineinfile:
       dest: /etc/modprobe.d/blacklist.conf
+      insertafter: "{{ item.insertafter }}"
       regexp: "{{ item.regexp }}"
       line: "{{ item.line }}"
       create: yes
@@ -644,9 +645,11 @@
       group: root
       mode: "0644"
   with_items:
-      - regexp: "^(#)?blacklist usb-storage(\\s+|$)"
+      - insertafter: "^#blacklist usb-storage(\\s+|$)"
+        regexp: "^blacklist usb-storage(\\s+|$)"
         line: 'blacklist usb-storage'
-      - regexp: "^(#)?install usb-storage"
+      - insertafter: "^#install usb-storage"
+        regexp: "^install usb-storage"
         line: install usb-storage /bin/true
   when: rhel_07_020100
   tags:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -644,7 +644,7 @@
       group: root
       mode: "0644"
   with_items:
-      - regexp: "^(#)?blacklist usb-storage(\\s|$)"
+      - regexp: "^(#)?blacklist usb-storage(\\s+|$)"
         line: 'blacklist usb-storage'
       - regexp: "^(#)?install usb-storage"
         line: install usb-storage /bin/true


### PR DESCRIPTION
This is what the DISA benchmark looks for as of V2R4.
If you really wanted to go overboard, you could use /usr/bin/true, but
it'd fail the benchmark.

fixes: #270