### PR TITLE
parse_passwd: list comprehension instead of loop

### DIFF
--- a/tasks/parse_etc_passwd.yml
+++ b/tasks/parse_etc_passwd.yml
@@ -7,21 +7,24 @@
         check_mode: no
         register: rhel7stig_passwd_file_audit
 
-      - name: "PRELIM | {{ rhel7stig_passwd_tasks }} | Clear passwd variable"
-        set_fact:
-            rhel7stig_passwd: []
-
       - name: "PRELIM | {{ rhel7stig_passwd_tasks }} | Split passwd entries"
         set_fact:
-            rhel7stig_passwd: "{{ rhel7stig_passwd | default([]) + [ {
-                    'id': item_sp[0],
-                    'uid': item_sp[2] | int,
-                    'gid': item_sp[3] | int,
-                    'gecos': item_sp[4],
-                    'dir': item_sp[5],
-                    'shell': item_sp[6] } ] }}"
-        with_items: "{{ rhel7stig_passwd_file_audit.stdout_lines }}"
+            rhel7stig_passwd: "{{ rhel7stig_passwd_file_audit.stdout_lines | map('regex_replace', ld_passwd_regex, ld_passwd_yaml) | map('from_yaml') | list }}"
         vars:
-            item_sp: "{{ item.split(':') }}"
+            ld_passwd_regex: >-
+                ^(?P<id>[^:]*):(?P<password>[^:]*):(?P<uid>[^:]*):(?P<gid>[^:]*):(?P<gecos>[^:]*):(?P<dir>[^:]*):(?P<shell>[^:]*)
+            ld_passwd_yaml: |
+                id: >-4
+                    \g<id>
+                password: >-4
+                    \g<password>
+                uid: \g<uid>
+                gid: \g<gid>
+                gecos: >-4
+                    \g<gecos>
+                dir: >-4
+                    \g<dir>
+                shell: >-4
+                    \g<shell>
   tags:
       - always


### PR DESCRIPTION
This speeds up run time and reduces screen noise when parsing the `/etc/passwd` file.