### PR TITLE
add compatability jinja tests

### DIFF
--- a/test_plugins/rhel7_stig_ansible_backport.py
+++ b/test_plugins/rhel7_stig_ansible_backport.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2016, Ansible, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+
+def contains(seq, value):
+    '''Opposite of the ``in`` test, allowing use as a test in filters like ``selectattr``
+
+    .. versionadded:: 2.8
+    '''
+    return value in seq
+
+class TestModule:
+    ''' Ansible math jinja2 tests '''
+
+    def tests(self):
+        return {
+            # set theory
+            'contains':    contains,
+        }

--- a/test_plugins/rhel7_stig_jinja_compat.py
+++ b/test_plugins/rhel7_stig_jinja_compat.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017, the Jinja Team
+# BSD 3-Clause "New" or "Revised" License (see https://opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import operator
+
+def test_in(value, seq):
+    """Check if value is in seq.
+    Copied from Jinja 2.10 https://github.com/pallets/jinja/pull/665
+
+    .. versionadded:: 2.10
+    """
+    return value in seq
+
+
+class TestModule:
+    ''' Tests from jinja 2.10 for compat with older jinja2 on RHEL 7. '''
+
+    def tests(self):
+        return {
+            'in':          test_in,
+            '==':          operator.eq,
+            'eq':          operator.eq,
+            'equalto':     operator.eq,
+            '!=':          operator.ne,
+            'ne':          operator.ne,
+            '>':           operator.gt,
+            'gt':          operator.gt,
+            'greaterthan': operator.gt,
+            'ge':          operator.ge,
+            '>=':          operator.ge,
+            '<':           operator.lt,
+            'lt':          operator.lt,
+            'lessthan':    operator.lt,
+            '<=':          operator.le,
+            'le':          operator.le,
+        }


### PR DESCRIPTION
Ansible assumes these are in place and provided by jinja.

Also grabbed "contains" test from ansible-2.8, "just in case"