### PR TITLE
enable role for RHEL 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -371,7 +371,7 @@ rhel7stig_force_exact_packages: "{{ rhel7stig_disruption_high }}"
 # RHEL-07-010480 and RHEL-07-010490
 # Password protect the boot loader
 rhel7stig_bootloader_password: 'Boot1tUp!'
-rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt=ansible_machine_id) }}"
+rhel7stig_bootloader_password_hash: "{{ 'grub.pbkdf2.sha512.25000.4B656F6B706B4543544A656F44684541355874694C51.9FB9906DFBC1B84A13BA1FCDB2EA6A35E493A6A07ED4506ACF35EAA2F293E24083BFE2FBE4EE842296CC1AEDA26F70E1DD62AC768016DD68FFD8F63C95DFB819' if rhel7stig_bootloader_password == 'Boot1tUp!' else (rhel7stig_bootloader_password | grub2_hash(salt=ansible_machine_id)) }}"
 rhel7stig_boot_superuser: root
 rhel7stig_boot_password_config:
     - regexp: ^set superusers

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -538,6 +538,9 @@ rhel7stig_login_defaults:
 # RHEL-07-030300 uncomment and set the value to a remote IP address that can receive audit logs
 # rhel7stig_audisp_remote_server: 10.10.10.10
 
+# RHEL-07-030200 thru RHEL-07-030321
+rhel7stig_audisp_config_path: "{{ ansible_distribution_major_version is version_compare('8', '<') | ternary('/etc/audisp', '/etc/audit') }}"
+
 # RHEL-07-030330: set this to 25% of the free space in /var/log/audit (measured in megabytes)
 rhel7stig_auditd_space_left: "{{ ( ansible_mounts | json_query(rhel7stig_audit_disk_size_query) | int / 4 / 1024 / 1024 ) | int + 1 }}"
 rhel7stig_audit_disk_size_query: "[?mount=='{{ rhel7stig_audit_part }}'].size_total | [0]"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -563,6 +563,9 @@ rhel7stig_auth_settings:
 # RHEL-07-040820
 rhel7stig_ipsec_required: no
 
+# RHEL-07-041001
+rhel7stig_mfa_package: "{{ ansible_distribution_major_version is version_compare('8', '<') | ternary('pam_pkcs11', 'sssd-common') }}"
+
 # RHEL-07-010340
 # Setting to enable or disable fixes that depend on password-based authentication
 # i.e. if users authenticate with a means other than passwords (pubkey)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -362,7 +362,7 @@ rhel7stig_kdump_required: false
 rhel7stig_snmp_community: Endgam3Ladyb0g
 
 # RHEL-07-010090 acceptable values: screen, tmux
-rhel7stig_screen_package: screen
+rhel7stig_screen_package: "{{ ansible_distribution_major_version is version_compare('8', '<') | ternary('screen', 'tmux') }}"
 
 # whether to force role-specified packages to be installed regardless of the
 # presence of another compliant equivalent

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -437,7 +437,9 @@
             - rhel_07_021350_audit is failed
             - not ansible_check_mode or
               rhel_07_021350_audit.rc > 1
-  when: rhel_07_021350
+  when:
+      - rhel_07_021350
+      - ansible_distribution_major_version == '7'
   tags:
       - RHEL-07-021350
 

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1596,7 +1596,7 @@
       regexp: (?i)^ *active *=
       line: active = yes
   with_items:
-      - /etc/audisp/plugins.d/au-remote.conf
+      - "{{ rhel7stig_audisp_config_path }}/plugins.d/au-remote.conf"
   when:
       - rhel_07_030200
   tags:
@@ -1605,7 +1605,7 @@
 
 - name: "MEDIUM | RHEL-07-030300 | PATCH | The Red Hat Enterprise Linux operating system must off-load audit records onto a different system or media from the system being audited."
   lineinfile:
-      path: /etc/audisp/audisp-remote.conf
+      path: "{{ rhel7stig_audisp_config_path }}/audisp-remote.conf"
       regexp: ^remote_server *=
       line: remote_server = {{ rhel7stig_audisp_remote_server }}
   when: rhel_07_030300 and rhel7stig_audisp_remote_server
@@ -1615,7 +1615,7 @@
 
 - name: "MEDIUM | RHEL-07-030310 | PATCH | The Red Hat Enterprise Linux operating system must encrypt the transfer of audit records off-loaded onto a different system or media from the system being audited."
   lineinfile:
-      path: /etc/audisp/audisp-remote.conf
+      path: "{{ rhel7stig_audisp_config_path }}/audisp-remote.conf"
       regexp: ^enable_krb5 +=
       line: enable_krb5 = yes
   when: rhel_07_030310
@@ -1625,7 +1625,7 @@
 
 - name: "MEDIUM | RHEL-07-030320 | PATCH | The Red Hat Enterprise Linux operating system must be configured so that the audit system takes appropriate action when the audit storage volume is full."
   lineinfile:
-      path: /etc/audisp/audisp-remote.conf
+      path: "{{ rhel7stig_audisp_config_path }}/audisp-remote.conf"
       regexp: ^disk_full_action +=
       line: "disk_full_action = {{ rhel7stig_audisp_disk_full_action }}"
   when: rhel_07_030320
@@ -1635,7 +1635,7 @@
 
 - name: "MEDIUM | RHEL-07-030321 | PATCH | The Red Hat Enterprise Linux operating system must be configured so that the audit system takes appropriate action when there is an error sending audit records to a remote system."
   lineinfile:
-      path: /etc/audisp/audisp-remote.conf
+      path: "{{ rhel7stig_audisp_config_path }}/audisp-remote.conf"
       regexp: ^network_failure_action +=
       line: "network_failure_action = {{ rhel7stig_audisp_network_failure_action }}"
   when: rhel_07_030321

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2683,7 +2683,7 @@
 
 - name: "MEDIUM | RHEL-07-041001 | The Red Hat Enterprise Linux operating system must have the required packages for multifactor authentication installed."
   yum:
-      name: pam_pkcs11
+      name: "{{ rhel7stig_mfa_package }}"
       state: present
   when: rhel_07_041001
   tags:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2723,7 +2723,9 @@
       path: /etc/pam_pkcs11/pam_pkcs11.conf
       regexp: (?im)^([ \t]*cert_policy[ \t]*=(?:[^ \t\n]|[ \t](?!ocsp_on,))*?)(?:[ \t]ocsp_on,[ \t]*)?[ \t]*((?:[^,\n]|,(?![ \t]*ocsp_on,))*?)(?:,[ \t]*ocsp_on)?;$
       replace: '\1 ocsp_on, \2;'
-  when: rhel_07_041003
+  when:
+      - rhel_07_041003
+      - ansible_distribution_major_version is version_compare('8', '<')
   tags:
       - RHEL-07-041003
 

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2612,7 +2612,7 @@
 - name: "MEDIUM | RHEL-07-040730 | PATCH | The Red Hat Enterprise Linux operating system must not have an X Windows display manager installed unless approved."
   yum:
       name:
-          - "@x11"
+          - "{{ ansible_distribution_major_version is version_compare('8', '<') | ternary('@x11', '@base-x') }}"
           - xorg-x11-server-common
       state: absent
   check_mode: "{{ rhel7stig_disruptive_check_mode }}"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -651,7 +651,7 @@
 - name: "MEDIUM | RHEL-07-010481 | The Red Hat Enterprise Linux operating system must require authentication upon booting into single-user and maintenance modes."
   block:
       - name: "MEDIUM | RHEL-07-010481 | PATCH | Check if the packaged rescue.service file was edited directly"
-        shell: "cat /usr/lib/systemd/system/rescue.service | grep 'ExecStart=.*/usr/sbin/sulogin'"
+        shell: "cat /usr/lib/systemd/system/rescue.service | grep 'ExecStart=.*sulogin'"
         changed_when: no
         failed_when: no
         check_mode: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,11 @@
 
 - name: Check OS version and family
   assert:
-      that: ansible_os_family == 'RedHat' and ansible_distribution_major_version is version_compare('7', '==')
-      msg: "This role can only be run against RHEL/CENTOS 7. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
+      that:
+          - ansible_os_family == 'RedHat'
+          - ansible_distribution_major_version is version_compare('7', '==') or
+            ansible_distribution_major_version is version_compare('8', '==')
+      msg: "This role can only be run against RHEL/CENTOS 7/8. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
   tags:
       - always
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -279,13 +279,19 @@
       - ansible_host | default(inventory_hostname) in ['localhost', '127.0.0.1']
       - rhel_07_020030 or rhel_07_010480
 
-- name: "PRELIM | RHEL-07-020210 | RHEL-07-020220| Install SELinux related dependencies"
+- name: "PRELIM | RHEL-07-020210 | RHEL-07-020220 | Install SELinux related dependencies"
   yum:
       name:
-          - libselinux-python
+          - "{{ ansible_distribution_major_version is version_compare('8', '<') | ternary('libselinux-python', 'python3-libselinux') }}"
           - selinux-policy-targeted
   when:
       - rhel_07_020210 or rhel_07_020220
+  tags:
+      - cat1
+      - high
+      - patch
+      - RHEL-07-020210
+      - RHEL-07-020220
 
 - name: "PRELIM | Bare bones SSH Server"
   block:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -277,6 +277,7 @@
       name: python-passlib
   when:
       - ansible_host | default(inventory_hostname) in ['localhost', '127.0.0.1']
+      - ansible_distribution_major_version is version_compare('8', '<')  # python passlib not available on RHEL 8
       - rhel_07_020030 or rhel_07_010480
 
 - name: "PRELIM | RHEL-07-020210 | RHEL-07-020220 | Install SELinux related dependencies"


### PR DESCRIPTION
These changes make it so that the RHEL7-STIG role can be run cleanly on RHEL 8.