### PR TITLE
Changed grub salt to machine_id from ansible_facts.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -370,7 +370,7 @@ rhel7stig_force_exact_packages: "{{ rhel7stig_disruption_high }}"
 # RHEL-07-010480 and RHEL-07-010490
 # Password protect the boot loader
 rhel7stig_bootloader_password: 'Boot1tUp!'
-rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt=rhel7stig_machine_id) }}"
+rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt=ansible_machine_id) }}"
 rhel7stig_boot_superuser: root
 rhel7stig_boot_password_config:
     - regexp: ^set superusers

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -370,7 +370,7 @@ rhel7stig_force_exact_packages: "{{ rhel7stig_disruption_high }}"
 # RHEL-07-010480 and RHEL-07-010490
 # Password protect the boot loader
 rhel7stig_bootloader_password: 'Boot1tUp!'
-rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt='KeokpkECTJeoDhEA5XtiLQ') }}"
+rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt=ansible_machine_id) }}"
 rhel7stig_boot_superuser: root
 rhel7stig_boot_password_config:
     - regexp: ^set superusers

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -370,7 +370,7 @@ rhel7stig_force_exact_packages: "{{ rhel7stig_disruption_high }}"
 # RHEL-07-010480 and RHEL-07-010490
 # Password protect the boot loader
 rhel7stig_bootloader_password: 'Boot1tUp!'
-rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt=ansible_machine_id) }}"
+rhel7stig_bootloader_password_hash: "{{ rhel7stig_bootloader_password | grub2_hash(salt=rhel7stig_machine_id) }}"
 rhel7stig_boot_superuser: root
 rhel7stig_boot_password_config:
     - regexp: ^set superusers

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -307,40 +307,11 @@
   when: rhel7stig_ssh_required
 
 - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID"
-  block:
-      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Check for /etc/machine-id"
-        stat:
-            path: /etc/machine-id
-        register: rhel7stig_etc_machine_id_stat
-
-      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /etc/machine-id"
-        slurp:
-            src: /etc/machine-id
-        register: rhel7stig_raw_etc_machine_id
-        when: rhel7stig_etc_machine_id_stat.stat.exists
-
-      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Assign machine ID to fact"
-        set_fact: rhel7stig_machine_id="{{ rhel7stig_raw_etc_machine_id['content'] | b64decode | regex_search('([a-f0-9]+)') }}"
-        when:
-            - rhel7stig_etc_machine_id_stat.stat.exists
-            - rhel7stig_raw_etc_machine_id is defined
-
-      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Check for /var/lib/dbus/machine-id"
-        stat:
-            path: /var/lib/dbus/machine-id
-        register: rhel7stig_var_lib_dbus_machine_id_stat
-
-      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /var/lib/dbus/machine-id"
-        slurp:
-            src: /var/lib/dbus/machine-id
-        register: rhel7stig_raw_var_lib_dbus_machine_id
-        when: rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
-
-      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Assign machine ID to fact"
-        set_fact: rhel7stig_machine_id="{{ rhel7stig_raw_var_lib_dbus_machine_id['content'] | b64decode | regex_search('([a-f0-9]+)') }}"
-        when:
-            - rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
-            - rhel7stig_raw_var_lib_dbus_machine_id is defined
+  setup:
+      gather_subset: machine_id,!all,!min
+      filter: ansible_machine_id
+  when:
+      - ansible_machine_id is not defined
   when:
       - rhel_07_010482 or
         rhel_07_010491

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -312,7 +312,6 @@
       filter: ansible_machine_id
   when:
       - ansible_machine_id is not defined
-  when:
       - rhel_07_010482 or
         rhel_07_010491
   tags:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -314,8 +314,16 @@
         register: rhel7stig_etc_machine_id_stat
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /etc/machine-id"
-        set_fact: rhel7stig_machine_id="{{ lookup('file', '/etc/machine-id').splitlines()[0] }}"
+        slurp:
+          src: /etc/machine-id
+        register: rhel7stig_raw_etc_machine_id
         when: rhel7stig_etc_machine_id_stat.stat.exists
+
+      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Assign machine ID to fact"
+        set_fact: rhel7stig_machine_id="{{ rhel7stig_raw_etc_machine_id['content'] | b64decode | regex_search('([a-f0-9]+)') }}"
+        when:
+          - rhel7stig_etc_machine_id_stat.stat.exists
+          - rhel7stig_raw_etc_machine_id is defined
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Check for /var/lib/dbus/machine-id"
         stat:
@@ -323,8 +331,16 @@
         register: rhel7stig_var_lib_dbus_machine_id_stat
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /var/lib/dbus/machine-id"
-        set_fact: rhel7stig_machine_id="{{ lookup('file', '/var/lib/dbus/machine-id').splitlines()[0] }}"
+        slurp:
+          src: /var/lib/dbus/machine-id
+        register: rhel7stig_raw_var_lib_dbus_machine_id
         when: rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
+
+      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Assign machine ID to fact"
+        set_fact: rhel7stig_machine_id="{{ rhel7stig_raw_var_lib_dbus_machine_id['content'] | b64decode | regex_search('([a-f0-9]+)') }}"
+        when:
+          - rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
+          - rhel7stig_raw_var_lib_dbus_machine_id is defined
   when:
       - rhel_07_010482 or
         rhel_07_010491

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -305,3 +305,31 @@
         when: not rhel7stig_ssh_host_rsa_key_stat.stat.exists
         notify: clean up ssh host key
   when: rhel7stig_ssh_required
+
+- name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID"
+  block:
+      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Check for /etc/machine-id"
+        stat:
+            path: /etc/machine-id
+        register: rhel7stig_etc_machine_id_stat
+
+      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /etc/machine-id"
+        set_fact: rhel7stig_machine_id="{{ lookup('file', '/etc/machine-id').splitlines()[0] }}"
+        when: rhel7stig_etc_machine_id_stat.stat.exists
+
+      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Check for /var/lib/dbus/machine-id"
+        stat:
+            path: /var/lib/dbus/machine-id
+        register: rhel7stig_var_lib_dbus_machine_id_stat
+
+      - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /var/lib/dbus/machine-id"
+        set_fact: rhel7stig_machine_id="{{ lookup('file', '/var/lib/dbus/machine-id').splitlines()[0] }}"
+        when: rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
+  when:
+      - rhel_07_010482 or
+        rhel_07_010491
+  tags:
+      - cat1
+      - high
+      - RHEL-07-010482
+      - RHEL-07-010491

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -315,15 +315,15 @@
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /etc/machine-id"
         slurp:
-          src: /etc/machine-id
+            src: /etc/machine-id
         register: rhel7stig_raw_etc_machine_id
         when: rhel7stig_etc_machine_id_stat.stat.exists
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Assign machine ID to fact"
         set_fact: rhel7stig_machine_id="{{ rhel7stig_raw_etc_machine_id['content'] | b64decode | regex_search('([a-f0-9]+)') }}"
         when:
-          - rhel7stig_etc_machine_id_stat.stat.exists
-          - rhel7stig_raw_etc_machine_id is defined
+            - rhel7stig_etc_machine_id_stat.stat.exists
+            - rhel7stig_raw_etc_machine_id is defined
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Check for /var/lib/dbus/machine-id"
         stat:
@@ -332,15 +332,15 @@
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Gather machine ID from /var/lib/dbus/machine-id"
         slurp:
-          src: /var/lib/dbus/machine-id
+            src: /var/lib/dbus/machine-id
         register: rhel7stig_raw_var_lib_dbus_machine_id
         when: rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
 
       - name: "PRELIM | RHEL-07-010482 | RHEL-07-010491 | Assign machine ID to fact"
         set_fact: rhel7stig_machine_id="{{ rhel7stig_raw_var_lib_dbus_machine_id['content'] | b64decode | regex_search('([a-f0-9]+)') }}"
         when:
-          - rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
-          - rhel7stig_raw_var_lib_dbus_machine_id is defined
+            - rhel7stig_var_lib_dbus_machine_id_stat.stat.exists
+            - rhel7stig_raw_var_lib_dbus_machine_id is defined
   when:
       - rhel_07_010482 or
         rhel_07_010491


### PR DESCRIPTION
This is a quick fix to address https://github.com/MindPointGroup/RHEL7-STIG/issues/222.  I've validated that it successfully pulls the machine ID and uses it as the salt in the hash.

fixes #222