### PR TITLE
Allow UUID home mounts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -566,6 +566,11 @@ rhel7stig_ipsec_required: no
 rhel7stig_using_password_auth: yes
 
 rhel7stig_availability_override: false
+
+# RHEL-07-021000
+# Setting to enable use of UUID for fstab entries instead of device
+rhel7stig_using_uuid_fstab: false
+
 # auditd_failure_flag
 # 2    Tells your system to perform an immediate shutdown without
 #      flushing any pending data to disk when the limits of your

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1289,7 +1289,7 @@
   mount:
       path: /home
       state: mounted
-      src: "{{ home_mount.device }}"
+      src: "{{ \"UUID={}\".format(home_mount.uuid) if rhel7stig_using_uuid_fstab else home_mount.device }}"
       fstype: "{{ home_mount.fstype }}"
       opts: "{{ home_mount.options }},nosuid"
   when:


### PR DESCRIPTION
Set rhel7stig_using_uuid_fstab to true to mount the /home volume
by its UUID instead of device