### PR TITLE
Change file operation to not follow symlinks

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1238,6 +1238,7 @@
         file:
             path: "{{ item.0 }}"
             recurse: yes
+            follow: False
             mode: a-st,g-w,o-rwx
         register: rhel_07_020680_patch
         when:


### PR DESCRIPTION
Set follow to false for the file module so it does not fail on recursive directory trees like the tests direcitory in this role.

Fixes #320 