### PR TITLE
Add sudoers tag to related prelim task

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -70,6 +70,7 @@
       - medium
       - RHEL-07-010340
       - RHEL-07-010350
+      - sudoers
 
 - name: "PRELIM | RHEL-07-010480 | RHEL-07-010490 | RHEL-07-021350 | Install grub2-tools."
   yum:


### PR DESCRIPTION
If you run the rhel7-stig role with --tags sudoers the following tasks will fail do to the needed prelim task not being ran:
https://github.com/MindPointGroup/RHEL7-STIG/blob/9139806317745b7996a49e5c29fb6ff88272da79/tasks/fix-cat2.yml#L582-L606


Added missing tag to the dependent prelim task